### PR TITLE
Add tornado log function

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+`0.3.0`_ (28 Aug 2015)
+----------------------
+- Install :func:`sprockets.logging.tornado_log_function` as the logging
+  function when we are running in release mode
+
 `0.2.2`_ (23 Jul 2015)
 ----------------------
 - Fixed requirements management... why is packaging so hard?!
@@ -17,3 +22,4 @@ Release History
 
 .. _0.2.0: https://github.com/sprockets/sprockets.http/compare/0.0.0...0.2.0
 .. _0.2.1: https://github.com/sprockets/sprockets.http/compare/0.2.0...0.2.1
+.. _0.3.0: https://github.com/sprockets/sprockets.http/compare/0.2.0...0.3.0

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 
-version_info = (0, 2, 2)
+version_info = (0, 3, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -11,6 +11,8 @@ import signal
 
 from tornado import httpserver, ioloop
 
+import sprockets.logging
+
 
 class Runner(object):
     """
@@ -63,6 +65,8 @@ class Runner(object):
             self.logger.info('starting 1 process on port %d', port_number)
             self.server.listen(port_number)
         else:
+            self.application.settings.setdefault(
+                'log_function', sprockets.logging.tornado_log_function)
             self.logger.info('starting processes on port %d', port_number)
             self.server.bind(port_number)
             self.server.start(0)


### PR DESCRIPTION
This installs `sprockets.logging.tornado_log_function` when we are running in release mode.
