### PR TITLE
Add shutdown hooks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,18 @@ API Documentation
 .. automodule:: sprockets.http
    :members:
 
+Application Callbacks
+---------------------
+Starting with version 0.4.0, :func:`sprockets.http.run` augments the
+:class:`tornado.web.Application` instance with a new attribute named
+``runner_callbacks`` which is a dictionary of lists of functions to
+call when specific events occur.  The only supported event is
+**shutdown**.  When the application receives a stop signal, it will
+run each of the callbacks before terminating the application instance.
+
+See :func:`sprockets.http.run` for a detailed description of how to
+install the runner callbacks.
+
 Internal Interfaces
 -------------------
 .. automodule:: sprockets.http.runner

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Release History
 ----------------------
 - Run callbacks from ``application.runner_callbacks['shutdown']`` when
   the application is shutting down.
+- Add ``number_of_procs`` parameter to ``sprockets.http``.
 
 `0.3.0`_ (28 Aug 2015)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+`0.4.0`_ (24 Sep 2015)
+----------------------
+- Run callbacks from ``application.runner_callbacks['shutdown']`` when
+  the application is shutting down.
+
 `0.3.0`_ (28 Aug 2015)
 ----------------------
 - Install :func:`sprockets.logging.tornado_log_function` as the logging
@@ -23,3 +28,4 @@ Release History
 .. _0.2.0: https://github.com/sprockets/sprockets.http/compare/0.0.0...0.2.0
 .. _0.2.1: https://github.com/sprockets/sprockets.http/compare/0.2.0...0.2.1
 .. _0.3.0: https://github.com/sprockets/sprockets.http/compare/0.2.0...0.3.0
+.. _0.4.0: https://github.com/sprockets/sprockets.http/compare/0.3.0...0.4.0

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 
-version_info = (0, 3, 0)
+version_info = (0, 4, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 
@@ -35,6 +35,18 @@ def run(create_application, settings=None):
     specified port.  If this key is not present, then the :envvar:`PORT`
     environment variable determines which port to bind to.  The
     default port is 8000 if nothing overrides it.
+
+    .. rubric:: application.runner_callbacks['shutdown']
+
+    The ``runner_callbacks`` attribute is a :class:`dict` of lists
+    of functions to call when an event occurs.  The *shutdown* key
+    contains functions that are invoked when a stop signal is
+    received *before* the IOLoop is stopped.
+
+    This attribute will be created **AFTER** `create_application` is
+    called and **BEFORE** this function returns.  If the attribute
+    exists on the instance returned from `create_application` , then
+    it will be used as-is.
 
     """
     from . import runner

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -36,6 +36,12 @@ def run(create_application, settings=None):
     environment variable determines which port to bind to.  The
     default port is 8000 if nothing overrides it.
 
+    .. rubric:: settings['number_of_procs']
+
+    If the `settings` parameter includes a value for the ``number_of_procs``
+    key, then the application will be configured to run this many processes
+    unless in *debug* mode.  This is passed to ``HTTPServer.start``.
+
     .. rubric:: application.runner_callbacks['shutdown']
 
     The ``runner_callbacks`` attribute is a :class:`dict` of lists
@@ -58,5 +64,7 @@ def run(create_application, settings=None):
     runner._configure_logging(debug_mode)
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
+    num_procs = int(app_settings.pop('number_of_procs', '0'))
     server = runner.Runner(create_application(**app_settings))
-    server.run(port_number)
+
+    server.run(port_number, num_procs)

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -50,11 +50,13 @@ class Runner(object):
         except AttributeError:
             setattr(self.application, 'runner_callbacks', {'shutdown': []})
 
-    def start_server(self, port_number):
+    def start_server(self, port_number, number_of_procs=0):
         """
         Create a HTTP server and start it.
 
         :param int port_number: the port number to bind the server to
+        :param int number_of_procs: number of processes to pass to
+            Tornado's ``httpserver.HTTPServer.start``.
 
         If the application's ``debug`` setting is ``True``, then we are
         going to run in a single-process mode; otherwise, we'll let
@@ -73,20 +75,22 @@ class Runner(object):
                 'log_function', sprockets.logging.tornado_log_function)
             self.logger.info('starting processes on port %d', port_number)
             self.server.bind(port_number)
-            self.server.start(0)
+            self.server.start(number_of_procs)
 
-    def run(self, port_number):
+    def run(self, port_number, number_of_procs=0):
         """
         Create the server and run the IOLoop.
 
         :param int port_number: the port number to bind the server to
+        :param int number_of_procs: number of processes to pass to
+            Tornado's ``httpserver.HTTPServer.start``.
 
         If the application's ``debug`` setting is ``True``, then we are
         going to run in a single-process mode; otherwise, we'll let
         tornado decide how many sub-processes to spawn.
 
         """
-        self.start_server(port_number)
+        self.start_server(port_number, number_of_procs)
         ioloop.IOLoop.instance().start()
 
     def _on_signal(self, signo, frame):


### PR DESCRIPTION
This PR adds the ability to register functions to call after a signal has been received and before the IOLoop is torn down.  This makes it possible to gracefully stop periodic processing.

I also added the ability to override the number of processes that tornado will spawn in _release mode_.  The default value is zero which let's tornado decide.  There are occasions where you need to force to a single process (e.g., if you want to add a `PeriodicCallback` before you start the IOLoop).
