### PR TITLE
Make logging configurable

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`1.0.2`_ (10 Dec 2015)
+----------------------
+- Add ``log_config`` parameter to ``sprockets.http.run``
+
 `1.0.1`_ (20 Nov 2015)
 ----------------------
 - Add support for ``sprockets.mixins.mediatype`` in ``sprockets.http.mixins.ErrorWriter``
@@ -43,4 +47,5 @@ Release History
 .. _0.4.0: https://github.com/sprockets/sprockets.http/compare/0.3.0...0.4.0
 .. _1.0.0: https://github.com/sprockets/sprockets.http/compare/0.4.0...1.0.0
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
-.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.0.1...master
+.. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
+.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.0.2...master

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -62,10 +62,58 @@ def run(create_application, settings=None):
     debug_mode = bool(app_settings.get('debug',
                                        int(os.environ.get('DEBUG', 0)) != 0))
     app_settings['debug'] = debug_mode
-    logging.config.dictConfig(runner._get_logging_config(debug_mode))
+    logging.config.dictConfig(_get_logging_config(debug_mode))
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
     num_procs = int(app_settings.pop('number_of_procs', '0'))
     server = runner.Runner(create_application(**app_settings))
 
     server.run(port_number, num_procs)
+
+
+def _get_logging_config(debug):
+    if debug:
+        return {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'incremental': False,
+            'formatters': {
+                'debug': {
+                    'format': ('[%(asctime)s] %(levelname)-8s %(process)-6s '
+                               '%(name)s: %(message)s.')
+                },
+            },
+            'handlers': {
+                'debug-console': {
+                    'class': 'logging.StreamHandler',
+                    'stream': 'ext://sys.stdout',
+                    'level': 'DEBUG',
+                    'formatter': 'debug',
+                },
+            },
+            'root': {
+                'level': 'DEBUG',
+                'handlers': ['debug-console'],
+            }
+        }
+    else:
+        return {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'incremental': False,
+            'formatters': {
+                'json': {
+                    '()': 'sprockets.logging.JSONRequestFormatter',
+                },
+            },
+            'handlers': {
+                'console': {
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'json',
+                },
+            },
+            'root': {
+                'level': 'INFO',
+                'handlers': ['console'],
+            }
+        }

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 
@@ -61,7 +62,7 @@ def run(create_application, settings=None):
     debug_mode = bool(app_settings.get('debug',
                                        int(os.environ.get('DEBUG', 0)) != 0))
     app_settings['debug'] = debug_mode
-    runner._configure_logging(debug_mode)
+    logging.config.dictConfig(runner._get_logging_config(debug_mode))
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
     num_procs = int(app_settings.pop('number_of_procs', '0'))

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -2,11 +2,11 @@ import logging
 import os
 
 
-version_info = (1, 0, 1)
+version_info = (1, 0, 2)
 __version__ = '.'.join(str(v) for v in version_info)
 
 
-def run(create_application, settings=None):
+def run(create_application, settings=None, log_config=None):
     """
     Run a Tornado create_application.
 
@@ -15,6 +15,11 @@ def run(create_application, settings=None):
     :param dict|None settings: optional configuration dictionary
         that will be passed through to ``create_application``
         as kwargs.
+    :param dict|None log_config: optional logging configuration
+        dictionary to use.  By default, a reasonable logging
+        configuration is generated based on settings.  If you
+        need to override the configuration, then use this parameter.
+        It is passed as-is to :func:`logging.config.dictConfig`.
 
     .. rubric:: settings['debug']
 
@@ -62,7 +67,8 @@ def run(create_application, settings=None):
     debug_mode = bool(app_settings.get('debug',
                                        int(os.environ.get('DEBUG', 0)) != 0))
     app_settings['debug'] = debug_mode
-    logging.config.dictConfig(_get_logging_config(debug_mode))
+    logging.config.dictConfig(_get_logging_config(debug_mode)
+                              if log_config is None else log_config)
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
     num_procs = int(app_settings.pop('number_of_procs', '0'))

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -6,7 +6,7 @@ Run a Tornado HTTP service.
 - :class:`.Runner`: encapsulates the running of the application
 
 """
-import logging.config
+import logging
 import signal
 
 from tornado import httpserver, ioloop
@@ -118,57 +118,3 @@ class Runner(object):
 
         self.logger.info('stopping within %s seconds', self.shutdown_limit)
         maybe_stop()
-
-
-def _get_logging_config(debug):
-    """
-    Retrieve dictionary-based logging configuration.
-
-    :param bool debug: are we running in debug mode?
-
-    """
-    if debug:
-        return {
-            'version': 1,
-            'disable_existing_loggers': False,
-            'incremental': False,
-            'formatters': {
-                'debug': {
-                    'format': ('[%(asctime)s] %(levelname)-8s %(process)-6s '
-                               '%(name)s: %(message)s.')
-                },
-            },
-            'handlers': {
-                'debug-console': {
-                    'class': 'logging.StreamHandler',
-                    'stream': 'ext://sys.stdout',
-                    'level': 'DEBUG',
-                    'formatter': 'debug',
-                },
-            },
-            'root': {
-                'level': 'DEBUG',
-                'handlers': ['debug-console'],
-            }
-        }
-    else:
-        return {
-            'version': 1,
-            'disable_existing_loggers': False,
-            'incremental': False,
-            'formatters': {
-                'json': {
-                    '()': 'sprockets.logging.JSONRequestFormatter',
-                },
-            },
-            'handlers': {
-                'console': {
-                    'class': 'logging.StreamHandler',
-                    'formatter': 'json',
-                },
-            },
-            'root': {
-                'level': 'INFO',
-                'handlers': ['console'],
-            }
-        }

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -120,15 +120,15 @@ class Runner(object):
         maybe_stop()
 
 
-def _configure_logging(debug):
+def _get_logging_config(debug):
     """
-    Configure the ``logging`` package appropriately.
+    Retrieve dictionary-based logging configuration.
 
     :param bool debug: are we running in debug mode?
 
     """
     if debug:
-        log_config = {
+        return {
             'version': 1,
             'disable_existing_loggers': False,
             'incremental': False,
@@ -152,7 +152,7 @@ def _configure_logging(debug):
             }
         }
     else:
-        log_config = {
+        return {
             'version': 1,
             'disable_existing_loggers': False,
             'incremental': False,
@@ -172,5 +172,3 @@ def _configure_logging(debug):
                 'handlers': ['console'],
             }
         }
-
-    logging.config.dictConfig(log_config)

--- a/tests.py
+++ b/tests.py
@@ -278,3 +278,8 @@ class RunTests(MockHelper, unittest.TestCase):
         sprockets.http.run(mock.Mock())
         self.logging_dict_config.assert_called_once_with(
             self.get_logging_config.return_value)
+
+    def test_that_logconfig_override_is_used(self):
+        sprockets.http.run(mock.Mock(), log_config=mock.sentinel.config)
+        self.logging_dict_config.assert_called_once_with(
+            mock.sentinel.config)

--- a/tests.py
+++ b/tests.py
@@ -217,7 +217,7 @@ class RunTests(MockHelper, unittest.TestCase):
         super(RunTests, self).setUp()
         self.runner_cls = self.start_mock('sprockets.http.runner.Runner')
         self.get_logging_config = self.start_mock(
-            'sprockets.http.runner._get_logging_config')
+            'sprockets.http._get_logging_config')
         self.get_logging_config.return_value = {'version': 1}
         self.logging_dict_config = self.start_mock(
             'sprockets.http.logging.config').dictConfig

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,13 @@
+import contextlib
 import logging
+import os
 import json
-import mock
+import unittest
 
 from tornado import httputil, testing, web
+import mock
 
-from sprockets.http import mixins
+import sprockets.http.mixins
 import examples
 
 
@@ -18,12 +21,44 @@ class RecordingHandler(logging.Handler):
         self.emitted.append((record, self.format(record)))
 
 
-class RaisingHandler(mixins.ErrorLogger, mixins.ErrorWriter,
+class RaisingHandler(sprockets.http.mixins.ErrorLogger,
+                     sprockets.http.mixins.ErrorWriter,
                      web.RequestHandler):
 
     def get(self, status_code):
         raise web.HTTPError(int(status_code),
                             reason=self.get_query_argument('reason', None))
+
+
+class MockHelper(unittest.TestCase):
+
+    def setUp(self):
+        super(MockHelper, self).setUp()
+        self._mocks = []
+
+    def tearDown(self):
+        super(MockHelper, self).tearDown()
+        for mocker in self._mocks:
+            mocker.stop()
+        del self._mocks[:]
+
+    def start_mock(self, target):
+        mocked = mock.patch(target)
+        self._mocks.append(mocked)
+        return mocked.start()
+
+
+@contextlib.contextmanager
+def override_environment_variable(name, value):
+    stash = os.environ.pop(name, None)
+    if value is not None:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        os.environ.pop(name, None)
+        if stash is not None:
+            os.environ[name] = stash
 
 
 class ErrorLoggerTests(testing.AsyncHTTPTestCase):
@@ -174,3 +209,64 @@ class ErrorWriterTests(testing.AsyncHTTPTestCase):
             'traceback': None
         })
         delattr(examples.StatusHandler, 'send_response')
+
+
+class RunTests(MockHelper, unittest.TestCase):
+
+    def setUp(self):
+        super(RunTests, self).setUp()
+        self.runner_cls = self.start_mock('sprockets.http.runner.Runner')
+        self.configure_logging = self.start_mock(
+            'sprockets.http.runner._configure_logging')
+
+    @property
+    def runner_instance(self):
+        return self.runner_cls.return_value
+
+    def test_that_runner_run_called_with_created_application(self):
+        create_app = mock.Mock()
+        sprockets.http.run(create_app)
+        self.assertEqual(create_app.call_count, 1)
+        self.runner_cls.assert_called_once_with(create_app.return_value)
+
+    def test_that_debug_envvar_enables_debug_flag(self):
+        create_app = mock.Mock()
+        with override_environment_variable('DEBUG', '1'):
+            sprockets.http.run(create_app)
+            create_app.assert_called_once_with(debug=True)
+            self.configure_logging.assert_called_once_with(True)
+
+    def test_that_false_debug_envvar_disables_debug_flag(self):
+        create_app = mock.Mock()
+        with override_environment_variable('DEBUG', '0'):
+            sprockets.http.run(create_app)
+            create_app.assert_called_once_with(debug=False)
+            self.configure_logging.assert_called_once_with(False)
+
+    def test_that_unset_debug_envvar_disables_debug_flag(self):
+        create_app = mock.Mock()
+        with override_environment_variable('DEBUG', None):
+            sprockets.http.run(create_app)
+            create_app.assert_called_once_with(debug=False)
+            self.configure_logging.assert_called_once_with(False)
+
+    def test_that_port_defaults_to_8000(self):
+        sprockets.http.run(mock.Mock())
+        self.runner_instance.run.called_once_with(8000, mock.ANY)
+
+    def test_that_port_envvar_sets_port_number(self):
+        with override_environment_variable('PORT', '8888'):
+            sprockets.http.run(mock.Mock())
+            self.runner_instance.run.called_once_with(8888, mock.ANY)
+
+    def test_that_port_kwarg_sets_port_number(self):
+        sprockets.http.run(mock.Mock(), settings={'port': 8888})
+        self.runner_instance.run.called_once_with(8888, mock.ANY)
+
+    def test_that_number_of_procs_defaults_to_zero(self):
+        sprockets.http.run(mock.Mock())
+        self.runner_instance.run.called_once_with(mock.ANY, 0)
+
+    def test_that_number_of_process_kwarg_sets_number_of_procs(self):
+        sprockets.http.run(mock.Mock(), settings={'number_of_procs': 1})
+        self.runner_instance.run.called_once_with(mock.ANY, 1)

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,3 @@ skip_missing_interpreters = True
 commands = nosetests []
 deps =
 	-rrequires/testing.txt
-
-[testenv:py27]
-deps =
-	-rrequires/testing.txt
-	mock>=1.0.1,<2

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ toxworkdir = build/tox
 skip_missing_interpreters = True
 
 [testenv]
-commands = nosetests []
+commands =
+    ./setup.py develop
+    nosetests []
 deps =
-	-rrequires/testing.txt
+    -rrequires/testing.txt


### PR DESCRIPTION
This PR adds a `log_config` parameter to `sprockets.http.run` that overrides the embedded logging configuration dictionary.
