### PR TITLE
Add before_run callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,15 @@ language: python
 python:
 - 2.7
 - 3.4
+- 3.5
 before_install:
+- pip install nose coverage codecov
 - pip install -r requires/testing.txt
 install:
 - pip install -e .
-script: nosetests
+script: nosetests --with-coverage
+after_success:
+- codecov
 sudo: false
 deploy:
   distributions: sdist bdist_wheel

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 AWeber Communications
+Copyright (c) 2015-2016 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,9 +10,22 @@ Application Callbacks
 Starting with version 0.4.0, :func:`sprockets.http.run` augments the
 :class:`tornado.web.Application` instance with a new attribute named
 ``runner_callbacks`` which is a dictionary of lists of functions to
-call when specific events occur.  The only supported event is
-**shutdown**.  When the application receives a stop signal, it will
-run each of the callbacks before terminating the application instance.
+call when specific events occur.  The following events are supported:
+
+:before_run:
+   This set of callbacks is invoked after Tornado forks sub-processes
+   (based on the ``number_of_procs`` setting) and before
+   :meth:`~tornado.ioloop.IOLoop.start` is called.  Callbacks can
+   safely access the :class:`~tornado.ioloop.IOLoop` without causing
+   the :meth:`~tornado.ioloop.IOLoop.start` method to explode.
+
+   If any callback raises an exception, then the application is
+   terminated **before** the IOLoop is started.
+
+:shutdown:
+   When the application receives a stop signal, it will run each of the
+   callbacks before terminating the application instance.  Exceptions
+   raised by the callbacks are simply logged.
 
 See :func:`sprockets.http.run` for a detailed description of how to
 install the runner callbacks.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ html_theme_options = {
     'description': 'Tornado application runner',
     'github_banner': True,
     'travis_button': True,
+    'codecov_button': True,
 }
 
 intersphinx_mapping = {

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Add support for the ``before_run`` callback set.
+
 `1.0.2`_ (10 Dec 2015)
 ----------------------
 - Add ``log_config`` parameter to ``sprockets.http.run``

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -48,17 +48,20 @@ def run(create_application, settings=None, log_config=None):
     key, then the application will be configured to run this many processes
     unless in *debug* mode.  This is passed to ``HTTPServer.start``.
 
-    .. rubric:: application.runner_callbacks['shutdown']
+    .. rubric:: application.runner_callbacks
 
     The ``runner_callbacks`` attribute is a :class:`dict` of lists
-    of functions to call when an event occurs.  The *shutdown* key
-    contains functions that are invoked when a stop signal is
-    received *before* the IOLoop is stopped.
+    of functions to call when an event occurs.  This attribute will be
+    created **AFTER** `create_application` is called and **BEFORE** this
+    function returns.  If the attribute exists on the instance returned
+    from `create_application` , then it will be used as-is.
 
-    This attribute will be created **AFTER** `create_application` is
-    called and **BEFORE** this function returns.  If the attribute
-    exists on the instance returned from `create_application` , then
-    it will be used as-is.
+    The *before_run* key contains functions that are invoked after
+    sub-processes are forked (if necessary) and before the IOLoop is
+    started.
+
+    The *shutdown* key contains functions that are invoked when a stop
+    signal is received *before* the IOLoop is stopped.
 
     """
     from . import runner

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -8,6 +8,7 @@ Run a Tornado HTTP service.
 """
 import logging
 import signal
+import sys
 
 from tornado import httpserver, ioloop
 
@@ -91,7 +92,10 @@ class Runner(object):
 
         If the application's ``debug`` setting is ``True``, then we are
         going to run in a single-process mode; otherwise, we'll let
-        tornado decide how many sub-processes to spawn.
+        tornado decide how many sub-processes to spawn.  In any case, the
+        applications *before_run* callbacks are invoked.  If a callback
+        raises an exception, then the application is terminated by calling
+        :func:`sys.exit`.
 
         """
         iol = ioloop.IOLoop.instance()
@@ -103,7 +107,7 @@ class Runner(object):
                 self.logger.error('before_run callback %r cancelled start',
                                   callback, exc_info=1)
                 self._shutdown()
-                return
+                sys.exit(70)
 
         iol.start()
 

--- a/tests.py
+++ b/tests.py
@@ -340,10 +340,16 @@ class CallbackTests(MockHelper, unittest.TestCase):
             another_callback)
         self.before_run_callback.side_effect = Exception
 
-        runner = sprockets.http.runner.Runner(self.application)
-        runner.run(8080)
+        sys_exit = mock.Mock()
+        sys_exit.side_effect = SystemExit
+        with mock.patch('sprockets.http.runner.sys') as sys_module:
+            sys_module.exit = sys_exit
+            with self.assertRaises(SystemExit):
+                runner = sprockets.http.runner.Runner(self.application)
+                runner.run(8080)
 
         self.before_run_callback.assert_called_once_with(self.application,
                                                          self.io_loop)
         another_callback.assert_not_called()
         self.shutdown_callback.assert_called_once_with(self.application)
+        sys_exit.assert_called_once_with(70)


### PR DESCRIPTION
This PR adds the `before_run` callback set which is invoked after the application is created and immediately before starting the `IOLoop`.  If any of the _before run_ callbacks raise an exception, then the application exits immediately without actually starting the `IOLoop`.
