### PR TITLE
Allow xheaders to be passed in the settings

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`1.1.2`_ (23 Feb 2016)
+----------------------
+- Allow xheaders to be set in the application.settings.
+
 `1.1.1`_ (15 Feb 2016)
 ----------------------
 - Delay grabbing the ``IOLoop`` instance until after fork.

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -48,6 +48,15 @@ def run(create_application, settings=None, log_config=None):
     key, then the application will be configured to run this many processes
     unless in *debug* mode.  This is passed to ``HTTPServer.start``.
 
+    .. rubric:: settings['xheaders']
+
+    If the `settings` parameter includes a value for the ``xheaders``
+    key, then the application will be configured to use headers, like
+    X-Real-IP, to get the user's IP address instead of attributing all
+    traffic to the load balancer's IP address. When running behind a load
+    balancer like nginx, it is recommended to pass xheaders=True. The default
+    value is False if nothing overrides it.
+
     .. rubric:: application.runner_callbacks
 
     The ``runner_callbacks`` attribute is a :class:`dict` of lists

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -70,8 +70,9 @@ class Runner(object):
         """
         signal.signal(signal.SIGTERM, self._on_signal)
         signal.signal(signal.SIGINT, self._on_signal)
+        xheaders = self.application.settings.get('xheaders', False)
 
-        self.server = httpserver.HTTPServer(self.application)
+        self.server = httpserver.HTTPServer(self.application, xheaders=xheaders)
         if self.application.settings.get('debug', False):
             self.logger.info('starting 1 process on port %d', port_number)
             self.server.listen(port_number)


### PR DESCRIPTION
This will tell Tornado to use headers like X-Real-IP to get the user’s IP address instead of attributing all traffic to the lbl’s IP address.
