### PR TITLE
Add async shutdown support and on_start callbacks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,11 @@ call when specific events occur.  The following events are supported:
    If any callback raises an exception, then the application is
    terminated **before** the IOLoop is started.
 
+:on_start:
+   This set of callbacks is invoked after Tornado forks sub-processes
+   (based on the ``number_of_procs`` setting) and **after**
+   :meth:`~tornado.ioloop.IOLoop.start` is called.
+
 :shutdown:
    When the application receives a stop signal, it will run each of the
    callbacks before terminating the application instance.  Exceptions

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,12 @@
 
 Release History
 ===============
+`1.2.0`_ (11 Mar 2016)
+----------------------
+- Add support for the ``on_start`` callback.
+- Add support to wait for the completion of ``shutdown`` callbacks that
+  return a future.
+- Adds new init params to runner.Runner for the three callback types
 
 `1.1.2`_ (23 Feb 2016)
 ----------------------
@@ -61,4 +67,5 @@ Release History
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
 .. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
 .. _1.1.0: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.1.0
-.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.1.0...master
+.. _1.2.0: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.2.0
+.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.2.0...master

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 
-version_info = (1, 1, 2)
+version_info = (1, 2, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 
@@ -69,8 +69,13 @@ def run(create_application, settings=None, log_config=None):
     sub-processes are forked (if necessary) and before the IOLoop is
     started.
 
+    The *on_start* key contains functions that are invoked when the IOLoop
+    is started.
+
     The *shutdown* key contains functions that are invoked when a stop
-    signal is received *before* the IOLoop is stopped.
+    signal is received *before* the IOLoop is stopped. These functions
+    can return a :class:`~tornado.concurrent.Future` to allow for asynchronous
+    processing of events during the shutdown phase.
 
     """
     from . import runner


### PR DESCRIPTION
- Adds support for waiting on a returned future in a shutdown callback
- Adds a new on_start callback that is invoked when the IOLoop is started
- Adds new init params to runner.Runner for the three callback types
