### PR TITLE
Add run command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,41 @@ It also takes care of configuring the standard `logging`_ module albeit
 in a opinionated way.  The goal is to let you write your application
 without worrying about figuring out how to run and monitor it reliably.
 
+From setup.py
+~~~~~~~~~~~~~
+If you want, you can even run your application directly from ``setup.py``::
+
+   $ ./setup.py httprun -a mymodule:make_app
+
+The ``httprun`` command is installed as a ``distutils.command`` when you
+install the ``sprockets.http`` package.  This command accepts the following
+command line parameters:
+
+:application:
+   The "callable" that returns your application.  You want to specify
+   whatever you are passing to ``sprockets.http.run()`` using a syntax
+   similar to a `setuptools console script`_.  Basically, this is a string
+   that contains the module name to import and the callable to invoke
+   separated by a colon (e.g., ``mypackage.module.submodule:function``).
+   **This is the only required parameter.**
+
+:env-file:
+   Optional name of a file containing environment variable definitions
+   to parse and load into the environment before running the application.
+   The file is a list of environment variables formatted as ``name=value``
+   with one setting on each line.  If the line starts with ``export``, then
+   the export portion is removed (for the sake of convenience).  If the
+   ``value`` portion is omitted, then the environment variable named will
+   be removed from the environment if it is present.
+
+:port:
+   Optional port number to bind the application to.  This will set the
+   ``PORT`` environment variable *before* running the application and
+   *after* the environment file is read.
+
 .. _logging: https://docs.python.org/3/library/logging.html#module-logging
+.. _setuptools console script: http://python-packaging.readthedocs.io/en/
+   latest/command-line-scripts.html#the-console-scripts-entry-point
 
 Error Logging
 -------------

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,1 @@
+h1.logo {font-size: 18pt}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ html_theme_options = {
     'travis_button': True,
     'codecov_button': True,
 }
+html_static_path = ['_static']
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/3/', None),

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Release History
 `Next Release`_
 ---------------
 - Add ``httprun`` setup.py command.
+- Use ``declare_namespace`` to declare the sprockets namespace package.
 
 `1.2.0`_ (11 Mar 2016)
 ----------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+`Next Release`_
+---------------
+- Add ``httprun`` setup.py command.
+
 `1.2.0`_ (11 Mar 2016)
 ----------------------
 - Add support for the ``on_start`` callback.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -71,5 +71,7 @@ Release History
 .. _1.0.1: https://github.com/sprockets/sprockets.http/compare/1.0.0...1.0.1
 .. _1.0.2: https://github.com/sprockets/sprockets.http/compare/1.0.1...1.0.2
 .. _1.1.0: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.1.0
+.. _1.1.1: https://github.com/sprockets/sprockets.http/compare/1.1.0...1.1.1
+.. _1.1.2: https://github.com/sprockets/sprockets.http/compare/1.1.1...1.1.2
 .. _1.2.0: https://github.com/sprockets/sprockets.http/compare/1.0.2...1.2.0
 .. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.2.0...master

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,5 @@ exclude = env,build
 cover-branches = 1
 cover-erase = 1
 cover-package = sprockets.http
+cover-html = 1
+cover-html-dir = build/coverage

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,9 @@ setuptools.setup(
     license='BSD',
     namespace_packages=['sprockets'],
     packages=setuptools.find_packages(),
+    entry_points={
+        'distutils.commands': ['httprun=sprockets.http.runner:RunCommand'],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: No Input/Output (Daemon)',

--- a/sprockets/__init__.py
+++ b/sprockets/__init__.py
@@ -1,7 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -90,7 +90,8 @@ class Runner(object):
         signal.signal(signal.SIGINT, self._on_signal)
         xheaders = self.application.settings.get('xheaders', False)
 
-        self.server = httpserver.HTTPServer(self.application, xheaders=xheaders)
+        self.server = httpserver.HTTPServer(self.application,
+                                            xheaders=xheaders)
         if self.application.settings.get('debug', False):
             self.logger.info('starting 1 process on port %d', port_number)
             self.server.listen(port_number)


### PR DESCRIPTION
This PR adds `httprun` as a distutils command when you install the package.  It makes commands like `./setup.py httprun -a package.module:make_app` a thing.  It is even nicer when combined with some entries in _setup.cfg_:

```
[httprun]
application = package.module:make_app
port = 8010
env-file = build/test-environment
```

Now all that you need to do is `./setup.py httprun` and you have a running instance of your application.
