### PR TITLE
Add application class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,12 +23,10 @@ your application wrapping code should look something like the following.
    from tornado import web
    import sprockets.http
 
-
    def make_app(**settings):
        return web.Application([
           # insert your handlers
        ], **settings)
-
 
    if __name__ == '__main__':
        sprockets.http.run(make_app)
@@ -40,6 +38,26 @@ when it is sent either an interrupt or terminate signal.
 It also takes care of configuring the standard `logging`_ module albeit
 in a opinionated way.  The goal is to let you write your application
 without worrying about figuring out how to run and monitor it reliably.
+
+If you are OO-minded, then you can also make use of a custom ``Application``
+class instead of writing a ``make_app`` function:
+
+.. code-block:: python
+
+   import sprockets.http.app
+
+   class Application(sprockets.http.app.Application):
+       def __init__(self, *args, **kwargs):
+           handlers = [
+               # insert your handlers
+           ]
+           super(Application, self).__init__(handlers, *args, **kwargs)
+
+   if __name__ == '__main__':
+       sprockets.http.run(Application)
+
+This approach is handy if you have application level state and logic that
+needs to be bundled together.
 
 From setup.py
 ~~~~~~~~~~~~~

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,1 +1,4 @@
-h1.logo {font-size: 18pt}
+h1.logo {font-size:inherit}
+th.field-name {hyphens: manual; -webkit-hyphens: none}
+dl.class dt {padding-left: 5em; padding-right: 5em; text-indent: -5em}
+dl.function dt {padding-left: 5em; padding-right: 5em; text-indent: -5em}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,3 +2,4 @@ h1.logo {font-size:inherit}
 th.field-name {hyphens: manual; -webkit-hyphens: none}
 dl.class dt {padding-left: 5em; padding-right: 5em; text-indent: -5em}
 dl.function dt {padding-left: 5em; padding-right: 5em; text-indent: -5em}
+div.seealso {background-color: initial; border: initial}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,44 +1,137 @@
 API Documentation
 =================
 
-Application Runner
-------------------
+Running your Application
+------------------------
+This library exposes a utility function named :func:`sprockets.http.run`
+for running your application.  You need to pass in a callable that accepts
+keyword parameters destined for :class:`tornado.web.Application` and return
+the application instance.
+
 .. autofunction:: sprockets.http.run
 
-Application Callbacks
-~~~~~~~~~~~~~~~~~~~~~
-Starting with version 0.4.0, :func:`sprockets.http.run` augments the
-:class:`tornado.web.Application` instance with a new attribute named
-``runner_callbacks`` which is a dictionary of lists of functions to
-call when specific events occur.  The following events are supported:
+.. code-block:: python
+   :caption: Using sprockets.http.run
 
-:before_run:
-   This set of callbacks is invoked after Tornado forks sub-processes
-   (based on the ``number_of_procs`` setting) and before
-   :meth:`~tornado.ioloop.IOLoop.start` is called.  Callbacks can
-   safely access the :class:`~tornado.ioloop.IOLoop` without causing
-   the :meth:`~tornado.ioloop.IOLoop.start` method to explode.
+   def create_application(**settings):
+      return web.Application(
+         [
+            # add your handlers here
+         ], **settings)
 
-   If any callback raises an exception, then the application is
-   terminated **before** the IOLoop is started.
+   if __name__ == '__main__':
+      sprockets.http.run(create_application)
 
-:on_start:
-   This set of callbacks is invoked after Tornado forks sub-processes
-   (based on the ``number_of_procs`` setting) and **after**
-   :meth:`~tornado.ioloop.IOLoop.start` is called.
+In version 0.4, support for a ``runner_callbacks`` attribute was added to the
+application instance.  It is a dictionary containing lists of callbacks to
+invoke at certain points in the application lifecycle.  If the application
+instance returned from your *make application* function defines the
+attribute, then :func:`sprockets.http.run` will make sure that they are
+invoked at the appropriate time.
 
-:shutdown:
-   When the application receives a stop signal, it will run each of the
-   callbacks before terminating the application instance.  Exceptions
-   raised by the callbacks are simply logged.
+The following example uses the callbacks to asynchronously connect to an
+imaginary database and maintain a :class:`tornado.locks.Event` that can be
+used to tell if the application can service requests or not.
 
-See :func:`sprockets.http.run` for a detailed description of how to
-install the runner callbacks.
+.. code-block:: python
+   :caption: Adding callbacks
 
-Internal Interfaces
-~~~~~~~~~~~~~~~~~~~
-.. automodule:: sprockets.http.runner
-   :members:
+   from tornado import gen, locks, web
+
+   def _connect_to_database(app, iol):
+      def _connected(future):
+         if future.exception():
+            coro = gen.sleep(0.5)
+            iol.add_future(coro, lambda f: _connect_to_database(app, iol))
+         else:
+            app.ready_to_serve.set()
+
+      future = dbconnector.connect()
+      iol.add_future(future, _connected)
+
+   def create_application(**settings):
+      app = web.Application(handlers, **settings)
+      callbacks = {
+         'before_run': lambda app, iol: app.ready_to_serve.clear(),
+         'on_start': _connect_to_database,
+      }
+      setattr(app, 'ready_to_serve', locks.Event())
+      setattr(app, 'runner_callbacks', callbacks)
+      return app
+
+   if __name__ == '__main__':
+      sprockets.http.run(create_application)
+
+Start with version 1.3, this method was codified further with the creation
+of the :class:`sprockets.http.app.Application` class.  Instead of manually
+poking attributes into the application object in your *make application*
+function, create a :class:`sprockets.http.app.Application` instance and set
+the callback attributes that *or* sub-class
+:class:`~sprockets.http.app.Application` and add customizations in the
+initializer as shown below.  The sub-class approach is the recommended if you
+have anything of interest in your application class.
+
+The following snippet re-implements the previous example.
+
+.. code-block:: python
+
+   class Application(sprockets.http.app.Application):
+      def __init__(self, **kwargs):
+         super(Application, self).__init__(
+            [
+               # additional handlers here
+            ],
+            **kwargs)
+         self.ready_to_serve = locks.Event()
+         self.on_start_callbacks.append(self._connect_to_database)
+         self.io_loop = None
+
+      def _create_database(self, app, io_loop):
+         self.io_loop = io_loop
+         self._connect()
+
+      def _connect(self, *ignored):
+         coro = dbconnector.connect()
+         self.io_loop.add_future(coro, self._on_connected)
+
+      def _on_connected(self, future):
+         if future.exception():
+            coro = gen.sleep(0.5)
+            self.io_loop.add_future(coro, self._connect)
+         else:
+            self.ready_to_serve.set()
+
+   if __name__ == '__main__':
+      sprockets.http.run(Application)
+
+Before Run Callbacks
+^^^^^^^^^^^^^^^^^^^^
+This set of callbacks is invoked after Tornado forks sub-processes
+(based on the ``number_of_procs`` setting) and before
+:meth:`~tornado.ioloop.IOLoop.start` is called.  Callbacks can
+safely access the :class:`~tornado.ioloop.IOLoop` without causing
+the :meth:`~tornado.ioloop.IOLoop.start` method to explode.
+
+If any callback raises an exception, then the application is
+terminated **before** the IOLoop is started.
+
+.. seealso:: :attr:`~sprockets.http.app.CallbackManager.before_run_callbacks`
+
+On Start Callbacks
+^^^^^^^^^^^^^^^^^^
+This set of callbacks is invoked after Tornado forks sub-processes
+(using :meth:`tornado.ioloop.IOLoop.spawn_callback`) and **after**
+:meth:`~tornado.ioloop.IOLoop.start` is called.
+
+.. seealso:: :attr:`~sprockets.http.app.CallbackManager.on_start_callbacks`
+
+Shutdown Callbacks
+^^^^^^^^^^^^^^^^^^
+When the application receives a stop signal, it will run each of the
+callbacks before terminating the application instance.  Exceptions
+raised by the callbacks are simply logged.
+
+.. seealso:: :attr:`~sprockets.http.app.CallbackManager.on_shutdown_callbacks`
 
 Response Logging
 ----------------
@@ -105,4 +198,12 @@ If :class:`~sprockets.mixins.mediatype.ContentMixin` is being used as well,
 document, otherwise it is sent as JSON.
 
 .. autoclass:: sprockets.http.mixins.ErrorWriter
+   :members:
+
+Internal Interfaces
+-------------------
+.. automodule:: sprockets.http.runner
+   :members:
+
+.. automodule:: sprockets.http.app
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -75,7 +75,7 @@ the event:
          maybe_future = super(StatusHandler, self).prepare()
          if concurrent.is_future(maybe_future):
             yield maybe_future
-         if not self._finished and not self.ready_to_serve.is_set():
+         if not self._finished and not self.application.ready_to_serve.is_set():
             self.set_header('Retry-After', '5')
             self.set_status(503, 'Not Ready')
             self.finish()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ html_theme_path = [alabaster.get_path()]
 html_sidebars = {
     '**': ['about.html', 'navigation.html'],
 }
+html_static_path = ['_static']
 html_theme_options = {
     'github_user': 'sprockets',
     'github_repo': 'sprockets.http',

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,13 @@
 
 Release History
 ===============
+`Next Release`_
+---------------
+- Separate the concerns of running the application from the callback
+  chains.  The latter has been refactored into :mod:`sprockets.http.app`.
+  This change is completely invisible to the outside world.
+- Officially deprecated the ``runner_callbacks`` application attribute.
+
 `1.3.3`_ (20 Sept)
 ------------------
 - Include correlation-id in the structured log data when logging.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,23 +2,23 @@
 
 Release History
 ===============
-`Next Release`_
----------------
+`1.4.0`_ (3 Nov 2016)
+---------------------
 - Separate the concerns of running the application from the callback
   chains.  The latter has been refactored into :mod:`sprockets.http.app`.
   This change is completely invisible to the outside world.
 - Officially deprecated the ``runner_callbacks`` application attribute.
 
-`1.3.3`_ (20 Sept)
-------------------
+`1.3.3`_ (20 Sept 2016)
+-----------------------
 - Include correlation-id in the structured log data when logging.
 
-`1.3.2`_ (19 Sept)
-------------------
+`1.3.2`_ (19 Sept 2016)
+-----------------------
 - Include the service and environment (if set) in the structured log data.
 
-`1.3.1`_ (16 Sept)
-------------------
+`1.3.1`_ (16 Sept 2016)
+-----------------------
 - Change the non-DEBUG log format to include structured data and a leading first byte for log level.
 
 `1.3.0`_ (11 Mar 2016)
@@ -100,4 +100,5 @@ Release History
 .. _1.3.1: https://github.com/sprockets/sprockets.http/compare/1.3.0...1.3.1
 .. _1.3.2: https://github.com/sprockets/sprockets.http/compare/1.3.1...1.3.2
 .. _1.3.3: https://github.com/sprockets/sprockets.http/compare/1.3.2...1.3.3
-.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.3.3...master
+.. _1.4.0: https://github.com/sprockets/sprockets.http/compare/1.3.3...1.4.0
+.. _Next Release: https://github.com/sprockets/sprockets.http/compare/1.4.0...master

--- a/examples.py
+++ b/examples.py
@@ -1,6 +1,6 @@
 from tornado import web
 
-from sprockets.http import mixins, run
+from sprockets.http import app, mixins, run
 
 
 class StatusHandler(mixins.ErrorLogger, mixins.ErrorWriter,
@@ -27,12 +27,14 @@ class StatusHandler(mixins.ErrorLogger, mixins.ErrorWriter,
             self.set_status(status_code)
 
 
-def make_app(**settings):
-    settings['debug'] = True  # disable JSON logging
-    return web.Application([
-        web.url(r'/status/(?P<status_code>\d+)', StatusHandler),
-    ], **settings)
+class Application(app.Application):
+
+    def __init__(self, **kwargs):
+        kwargs['debug'] = True
+        super(Application, self).__init__(
+            [web.url(r'/status/(?P<status_code>\d+)', StatusHandler)],
+            **kwargs)
 
 
 if __name__ == '__main__':
-    run(make_app)
+    run(Application)

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -3,7 +3,7 @@ import logging.config
 import os
 
 
-version_info = (1, 3, 3)
+version_info = (1, 4, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -54,26 +54,6 @@ def run(create_application, settings=None, log_config=None):
     balancer like nginx, it is recommended to pass xheaders=True. The default
     value is False if nothing overrides it.
 
-    .. rubric:: application.runner_callbacks
-
-    The ``runner_callbacks`` attribute is a :class:`dict` of lists
-    of functions to call when an event occurs.  This attribute will be
-    created **AFTER** `create_application` is called and **BEFORE** this
-    function returns.  If the attribute exists on the instance returned
-    from `create_application` , then it will be used as-is.
-
-    The *before_run* key contains functions that are invoked after
-    sub-processes are forked (if necessary) and before the IOLoop is
-    started.
-
-    The *on_start* key contains functions that are invoked when the IOLoop
-    is started.
-
-    The *shutdown* key contains functions that are invoked when a stop
-    signal is received *before* the IOLoop is stopped. These functions
-    can return a :class:`~tornado.concurrent.Future` to allow for asynchronous
-    processing of events during the shutdown phase.
-
     """
     from . import runner
 

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -67,7 +67,7 @@ class CallbackManager(object):
        :attr:`.before_run_callbacks`, :attr:`.on_start_callbacks`,
        and :attr:`on_shutdown_callbacks`.
 
-       .. deprecated:: 1.3
+       .. deprecated:: 1.4
 
           Use the property callbacks instead of this dictionary.  It
           will be going away in a future release.
@@ -134,9 +134,7 @@ class CallbackManager(object):
     @property
     def before_run_callbacks(self):
         """
-        Synchronous functions called before the IOLoop is started.
-
-        :rtype: list
+        List of synchronous functions called before the IOLoop is started.
 
         The *before_run* callbacks are called after the IOLoop is created
         and before it is started.  The callbacks are run synchronously and
@@ -150,9 +148,7 @@ class CallbackManager(object):
     @property
     def on_start_callbacks(self):
         """
-        Asynchronous functions spawned before the IOLoop is started.
-
-        :rtype: list
+        List of asynchronous functions spawned before the IOLoop is started.
 
         The *on_start* callbacks are spawned after the IOLoop is created
         and before it is started.  The callbacks are run asynchronously
@@ -167,9 +163,7 @@ class CallbackManager(object):
     @property
     def on_shutdown_callbacks(self):
         """
-        Functions when the application is shutting down.
-
-        :rtype: list
+        List of functions when the application is shutting down.
 
         The *on_shutdown* callbacks are called after the HTTP server has
         been stopped.  If a callback returns a
@@ -194,6 +188,9 @@ class Application(CallbackManager, web.Application):
     Using this class instead of the vanilla Tornado ``Application``
     class provides a clean way to customize application-level
     constructs such as connection pools.
+
+    Note that much of the functionality is implemented in
+    :class:`.CallbackManager`.
 
     """
 

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -1,0 +1,235 @@
+import logging
+import sys
+
+from tornado import concurrent, web
+
+
+class _ShutdownHandler(object):
+    """Keeps track of the application state during shutdown."""
+
+    def __init__(self, io_loop):
+        self.io_loop = io_loop
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.pending_callbacks = 0
+        self.shutdown_limit = 5
+        self.__deadline = None
+
+    def add_future(self, future):
+        self.pending_callbacks += 1
+        self.io_loop.add_future(future, self.on_shutdown_future_complete)
+
+    def on_shutdown_future_complete(self, future):
+        self.pending_callbacks -= 1
+        if future.exception():
+            if any(sys.exc_info()):
+                self.logger.exception('shutdown callback raised exception')
+            else:
+                self.logger.warning('shutdown callback raised exception: %r',
+                                    exc_info=(None, future.exception(), None))
+        else:
+            self.logger.debug('shutdown future completed: %r, %d pending',
+                              future.result(), self.pending_callbacks)
+
+        if not self.pending_callbacks:
+            self.on_shutdown_ready()
+
+    def on_shutdown_ready(self):
+        self.logger.info('starting IOLoop shutdown process')
+        self.__deadline = self.io_loop.time() + self.shutdown_limit
+        self._maybe_stop()
+
+    def _maybe_stop(self):
+        now = self.io_loop.time()
+        if (now < self.__deadline and
+                (self.io_loop._callbacks or self.io_loop._timeouts)):
+            self.io_loop.add_timeout(now + 1, self._maybe_stop)
+        else:
+            self.io_loop.stop()
+            self.logger.info('stopped IOLoop')
+
+
+class CallbackManager(object):
+    """
+    Application state management.
+
+    This is where the core of the application wrapper actually lives.
+    It is responsible for managing and calling the various application
+    callbacks.  Sub-classes are responsible for gluing in the actual
+    :class:`tornado.web.Application` object and the
+    :mod:`sprockets.http.runner` module is responsible for starting up
+    the HTTP stack and calling the :meth:`.run` and :meth:`.stop`
+    methods.
+
+    .. attribute:: runner_callbacks
+
+       :class:`dict` of lists of callback functions to call at
+       certain points in the application lifecycle.  See
+       :attr:`.before_run_callbacks`, :attr:`.on_start_callbacks`,
+       and :attr:`on_shutdown_callbacks`.
+
+       .. deprecated:: 1.3
+
+          Use the property callbacks instead of this dictionary.  It
+          will be going away in a future release.
+
+    """
+
+    def __init__(self, tornado_application, *args, **kwargs):
+        self.runner_callbacks = kwargs.pop('runner_callbacks', {})
+        super(CallbackManager, self).__init__(*args, **kwargs)
+
+        self._tornado_application = tornado_application
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.runner_callbacks.setdefault('before_run', [])
+        self.runner_callbacks.setdefault('on_start', [])
+        self.runner_callbacks.setdefault('shutdown', [])
+
+    def run(self, io_loop):
+        for callback in self.before_run_callbacks:
+            try:
+                callback(self._tornado_application, io_loop)
+            except Exception:
+                self.logger.error('before_run callback %r cancelled start',
+                                  callback, exc_info=1)
+                self.stop(io_loop)
+                raise
+
+        for callback in self.on_start_callbacks:
+            io_loop.spawn_callback(callback, self._tornado_application,
+                                   io_loop)
+
+    def stop(self, io_loop):
+        running_async = False
+        shutdown = _ShutdownHandler(io_loop)
+        for callback in self.on_shutdown_callbacks:
+            try:
+                maybe_future = callback(self._tornado_application)
+                if concurrent.is_future(maybe_future):
+                    shutdown.add_future(maybe_future)
+                    running_async = True
+            except Exception as error:
+                self.logger.warning('exception raised from shutdown '
+                                    'callback %r, ignored: %s',
+                                    callback, error, exc_info=1)
+
+        if not running_async:
+            shutdown.on_shutdown_ready()
+
+    @property
+    def before_run_callbacks(self):
+        """
+        Synchronous functions called before the IOLoop is started.
+
+        :rtype: list
+
+        The *before_run* callbacks are called after the IOLoop is created
+        and before it is started.  The callbacks are run synchronously and
+        the application will exit if a callback raises an exception.
+
+        **Signature**: callback(application, io_loop)
+
+        """
+        return self.runner_callbacks['before_run']
+
+    @property
+    def on_start_callbacks(self):
+        """
+        Asynchronous functions spawned before the IOLoop is started.
+
+        :rtype: list
+
+        The *on_start* callbacks are spawned after the IOLoop is created
+        and before it is started.  The callbacks are run asynchronously
+        via :meth:`tornado.ioloop.IOLoop.spawn_callback` as soon as the
+        IOLoop is started.
+
+        **Signature**: callback(application, io_loop)
+
+        """
+        return self.runner_callbacks['on_start']
+
+    @property
+    def on_shutdown_callbacks(self):
+        """
+        Functions when the application is shutting down.
+
+        :rtype: list
+
+        The *on_shutdown* callbacks are called after the HTTP server has
+        been stopped.  If a callback returns a
+        :class:`tornado.concurrent.Future` instance, then the future is
+        added to the IOLoop.
+
+        **Signature**: callback(application)
+
+        """
+        return self.runner_callbacks['shutdown']
+
+
+class Application(CallbackManager, web.Application):
+    """
+    Callback-aware version of :class:`tornado.web.Application`.
+
+    Using this class instead of the vanilla Tornado ``Application``
+    class provides a clean way to customize application-level
+    constructs such as connection pools.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Application, self).__init__(self, *args, **kwargs)
+
+
+class _ApplicationAdapter(CallbackManager):
+    """
+    Simple adapter for a :class:`tornado.web.Application` instance.
+
+    This class adapts/wraps a :class:`~tornado.web.Application` instance
+    and adds callback management in a backwards compatible manner.
+
+    .. warning::
+
+       Do not use this class directly.  Either switch to using
+       :class:`.Application` explicitly or call :func:`.wrap_application`
+       to wrap your current ``Application`` instance.
+
+    """
+
+    def __init__(self, application):
+        self._application = application
+        self.settings = self._application.settings
+        super(_ApplicationAdapter, self).__init__(
+            self._application,
+            runner_callbacks=getattr(application, 'runner_callbacks', {}))
+        setattr(self._application, 'runner_callbacks', self.runner_callbacks)
+
+
+def wrap_application(application, before_run, on_start, shutdown):
+    """
+    Wrap a tornado application in a callback-aware wrapper.
+
+    :param tornado.web.Application application: application to wrap.
+    :param list|NoneType before_run: optional list of callbacks
+        to invoke before the IOLoop is started.
+    :param list|NoneType on_start: optional list of callbacks to
+        register with :meth:`~tornado.IOLoop.spawn_callback`.
+    :param list|NoneType shutdown: optional list of callbacks to
+        invoke before stopping the IOLoop
+
+    :return: a wrapped application object
+    :rtype: sprockets.http.app.Application
+
+    """
+
+    before_run = [] if before_run is None else before_run
+    on_start = [] if on_start is None else on_start
+    shutdown = [] if shutdown is None else shutdown
+
+    if not isinstance(application, Application):
+        application = _ApplicationAdapter(application)
+
+    application.before_run_callbacks.extend(before_run)
+    application.on_start_callbacks.extend(on_start)
+    application.on_shutdown_callbacks.extend(shutdown)
+
+    return application

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -73,8 +73,8 @@ class Runner(object):
         signal.signal(signal.SIGINT, self._on_signal)
         xheaders = self.application.settings.get('xheaders', False)
 
-        self.server = httpserver.HTTPServer(self.application,
-                                            xheaders=xheaders)
+        self.server = httpserver.HTTPServer(
+            self.application.tornado_application, xheaders=xheaders)
         if self.application.settings.get('debug', False):
             self.logger.info('starting 1 process on port %d', port_number)
             self.server.listen(port_number)
@@ -110,7 +110,7 @@ class Runner(object):
         iol = ioloop.IOLoop.instance()
 
         try:
-            self.application.run(iol)
+            self.application.start(iol)
         except:
             self.logger.exception('application terminated during start, '
                                   'exiting')

--- a/tests.py
+++ b/tests.py
@@ -596,7 +596,7 @@ class RunCommandTests(MockHelper, unittest.TestCase):
         os_module.path.exists.return_value = False
 
         command = sprockets.http.runner.RunCommand(self.distribution)
-        command.application = examples.make_app
+        command.application = examples.Application
         command.env_file = 'file.conf'
         with self.assertRaises(distutils.errors.DistutilsArgError):
             command.ensure_finalized()
@@ -615,7 +615,7 @@ class RunCommandTests(MockHelper, unittest.TestCase):
             result_closure['result'] = result_closure['real_method']()
             return result_closure['result']
 
-        command.application = 'examples:make_app'
+        command.application = 'examples:Application'
         command.dry_run = False
         command._find_callable = patched
 

--- a/tests.py
+++ b/tests.py
@@ -266,12 +266,12 @@ class RunTests(MockHelper, unittest.TestCase):
 
     def test_that_port_defaults_to_8000(self):
         sprockets.http.run(mock.Mock())
-        self.runner_instance.run.called_once_with(8000, mock.ANY)
+        self.runner_instance.run.assert_called_once_with(8000, mock.ANY)
 
     def test_that_port_envvar_sets_port_number(self):
         with override_environment_variable('PORT', '8888'):
             sprockets.http.run(mock.Mock())
-            self.runner_instance.run.called_once_with(8888, mock.ANY)
+            self.runner_instance.run.assert_called_once_with(8888, mock.ANY)
 
     def test_that_port_kwarg_sets_port_number(self):
         sprockets.http.run(mock.Mock(), settings={'port': 8888})


### PR DESCRIPTION
This PR adds `sprockets.http.app.Application` which is a callback-aware specialization of `tornado.web.Application` that simplifies the runner and makes it easier to implement "on start" style behaviors.  The `runner_callbacks` dictionary is replaced by `list` properties (e.g., `app.before_run_callbacks` instead of `app.runner_callbacks['before_run']`) though the implementation is still a `dict` for compatibility purposes.