### PR TITLE
Add ready to serve event

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016 AWeber Communications
+Copyright (c) 2015-2017 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,8 +8,6 @@ for running your application.  You need to pass in a callable that accepts
 keyword parameters destined for :class:`tornado.web.Application` and return
 the application instance.
 
-.. autofunction:: sprockets.http.run
-
 .. code-block:: python
    :caption: Using sprockets.http.run
 
@@ -26,8 +24,32 @@ Since :func:`sprockets.http.run` accepts any callable, you can pass a
 class instance in as well.  The :class:`sprockets.http.app.Application`
 is a specialization of :class:`tornado.web.Application` that includes
 state management callbacks that work together with the ``run`` function
-and provide hooks for performing initialization and shutdown tasks.
+and provide hooks for performing initialization and shutdown tasks.  The
+callbacks are simply lists of callables that are invoked at well-defined
+points in the application life-cycle.
 
+Before Run Callbacks
+   This set of callbacks is invoked after Tornado forks sub-processes
+   (based on the ``number_of_procs`` setting) and before
+   :meth:`~tornado.ioloop.IOLoop.start` is called.  Callbacks can
+   safely access the :class:`~tornado.ioloop.IOLoop` without causing
+   the :meth:`~tornado.ioloop.IOLoop.start` method to explode.
+
+   If any callback raises an exception, then the application is
+   terminated **before** the IOLoop is started.
+
+On Start Callbacks
+   This set of callbacks is invoked after Tornado forks sub-processes
+   (using :meth:`tornado.ioloop.IOLoop.spawn_callback`) and **after**
+   :meth:`~tornado.ioloop.IOLoop.start` is called.
+
+Shutdown Callbacks
+   When the application receives a stop signal, it will run each of the
+   callbacks before terminating the application instance.  Exceptions
+   raised by the callbacks are simply logged.
+
+Examples
+^^^^^^^^
 The following example uses :class:`sprockets.http.app.Application` as a
 base class to implement asynchronously connecting to a mythical database
 when the application starts.
@@ -84,34 +106,12 @@ the event:
          self.set_status(200)
          self.write(json.dumps({'status': 'ok'})
 
-Before Run Callbacks
-^^^^^^^^^^^^^^^^^^^^
-This set of callbacks is invoked after Tornado forks sub-processes
-(based on the ``number_of_procs`` setting) and before
-:meth:`~tornado.ioloop.IOLoop.start` is called.  Callbacks can
-safely access the :class:`~tornado.ioloop.IOLoop` without causing
-the :meth:`~tornado.ioloop.IOLoop.start` method to explode.
+API Reference
+^^^^^^^^^^^^^
+.. autofunction:: sprockets.http.run
 
-If any callback raises an exception, then the application is
-terminated **before** the IOLoop is started.
-
-.. seealso:: :attr:`~sprockets.http.app.CallbackManager.before_run_callbacks`
-
-On Start Callbacks
-^^^^^^^^^^^^^^^^^^
-This set of callbacks is invoked after Tornado forks sub-processes
-(using :meth:`tornado.ioloop.IOLoop.spawn_callback`) and **after**
-:meth:`~tornado.ioloop.IOLoop.start` is called.
-
-.. seealso:: :attr:`~sprockets.http.app.CallbackManager.on_start_callbacks`
-
-Shutdown Callbacks
-^^^^^^^^^^^^^^^^^^
-When the application receives a stop signal, it will run each of the
-callbacks before terminating the application instance.  Exceptions
-raised by the callbacks are simply logged.
-
-.. seealso:: :attr:`~sprockets.http.app.CallbackManager.on_shutdown_callbacks`
+.. autoclass:: sprockets.http.app.Application
+   :members:
 
 Response Logging
 ----------------
@@ -187,3 +187,4 @@ Internal Interfaces
 
 .. automodule:: sprockets.http.app
    :members:
+   :exclude-members: Application

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Release History
 ---------------
 - Remove support for pre-4.x Tornado.  I believe that this has been
   broken since `1.2.0`_
+- Added ready to serve flag to :class:`sprockets.http.app.Application`
 
 `1.4.0`_ (3 Nov 2016)
 ---------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,11 @@
 
 Release History
 ===============
+`Next Release`_
+---------------
+- Remove support for pre-4.x Tornado.  I believe that this has been
+  broken since `1.2.0`_
+
 `1.4.0`_ (3 Nov 2016)
 ---------------------
 - Separate the concerns of running the application from the callback

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,1 +1,1 @@
-tornado>=3.1,<5
+tornado>=4.0,<5

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,18 @@ cover-erase = 1
 cover-package = sprockets.http
 cover-html = 1
 cover-html-dir = build/coverage
+
+[coverage:run]
+branch = 1
+parallel = 1
+source = sprockets.http
+
+# this is used by coverage combine to coalesce paths
+[coverage:paths]
+source =
+	build/tox/py27/lib/python2.7/site-packages/sprockets/http/
+	build/tox/py35/lib/python3.5/site-packages/sprockets/http/
+	build/tox/tornado40/lib/python3.5/site-packages/sprockets/http/
+	build/tox/tornado41/lib/python3.5/site-packages/sprockets/http/
+	build/tox/tornado42/lib/python3.5/site-packages/sprockets/http/
+	build/tox/tornado43/lib/python3.5/site-packages/sprockets/http/

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -242,13 +242,6 @@ class Application(_Application, web.Application):
             return _NotReadyDelegate(args[-1])
         return super(Application, self).start_request(*args)
 
-    def __call__(self, request):
-        if not self.ready_to_serve.is_set():
-            handler = web.ErrorHandler(self, request, status_code=503)
-            handler._execute([])
-            return handler
-        return super(Application, self).__call__(request)
-
 
 class _ApplicationAdapter(_Application):
     """

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -29,7 +29,7 @@ class _ShutdownHandler(object):
                 self.logger.exception('shutdown callback raised exception')
             else:
                 self.logger.warning('shutdown callback raised exception: %r',
-                                    exc_info=(None, future.exception(), None))
+                                    future.exception())
         else:
             self.logger.debug('shutdown future completed: %r, %d pending',
                               future.result(), self.pending_callbacks)

--- a/tests.py
+++ b/tests.py
@@ -18,6 +18,8 @@ from tornado import concurrent, httputil, ioloop, testing, web
 
 import sprockets.http.mixins
 import sprockets.http.runner
+import tornado
+
 import examples
 
 
@@ -108,10 +110,14 @@ class ErrorLoggerTests(testing.AsyncHTTPTestCase):
         self.assert_message_logged(
             logging.ERROR, 'failed with 500: {}', httputil.responses[500])
 
+    @unittest.skipIf(tornado.version_info[:2] == (4, 0),
+                     'send_error wuth custom status codes is broken in 4.0')
     def test_that_custom_status_codes_logged_as_unknown(self):
         self.fetch('/status/623')
         self.assert_message_logged(logging.ERROR, 'failed with 623: Unknown')
 
+    @unittest.skipIf(tornado.version_info[:2] == (4, 0),
+                     'send_error wuth custom status codes is broken in 4.0')
     def test_that_custom_reasons_are_supported(self):
         self.fetch('/status/456?reason=oops')
         self.assert_message_logged(logging.WARNING, 'failed with 456: oops')
@@ -193,6 +199,8 @@ class ErrorWriterTests(testing.AsyncHTTPTestCase):
         body = self._decode_response(response)
         self.assertEqual(body['message'], httputil.responses[500])
 
+    @unittest.skipIf(tornado.version_info[:2] == (4, 0),
+                     'send_error wuth custom status codes is broken in 4.0')
     def test_that_error_json_reason_contains_unknown_in_some_cases(self):
         response = self.fetch('/status/567')
         self.assertEqual(response.code, 567)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy,pypy3
+envlist = py27,py35,tornado40,tornado41,tornado42,tornado43
 indexserver =
 	default = https://pypi.python.org/simple
 toxworkdir = build/tox
@@ -8,6 +8,30 @@ skip_missing_interpreters = True
 [testenv]
 commands =
     ./setup.py develop
-    nosetests []
+    nosetests tests.py
 deps =
     -rrequires/testing.txt
+
+[testenv:tornado40]
+basepython = python3.4
+deps =
+	tornado>=4.0,<4.1
+	{[testenv]deps}
+
+[testenv:tornado41]
+basepython = python3.4
+deps =
+	tornado>=4.1,<4.2
+	{[testenv]deps}
+
+[testenv:tornado42]
+basepython = python3.4
+deps =
+	tornado>=4.2,<4.3
+	{[testenv]deps}
+
+[testenv:tornado43]
+basepython = python3.4
+deps =
+	tornado>=4.3,<4.4
+	{[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -4,34 +4,38 @@ indexserver =
 	default = https://pypi.python.org/simple
 toxworkdir = build/tox
 skip_missing_interpreters = True
+usedevelop = True
 
 [testenv]
 commands =
     ./setup.py develop
-    nosetests tests.py
+	coverage run {envbindir}/nosetests tests.py
 deps =
+	coverage
     -rrequires/testing.txt
 
 [testenv:tornado40]
-basepython = python3.4
+basepython = python3.5
 deps =
 	tornado>=4.0,<4.1
+	toro
 	{[testenv]deps}
 
 [testenv:tornado41]
-basepython = python3.4
+basepython = python3.5
 deps =
 	tornado>=4.1,<4.2
+	toro
 	{[testenv]deps}
 
 [testenv:tornado42]
-basepython = python3.4
+basepython = python3.5
 deps =
 	tornado>=4.2,<4.3
 	{[testenv]deps}
 
 [testenv:tornado43]
-basepython = python3.4
+basepython = python3.5
 deps =
 	tornado>=4.3,<4.4
 	{[testenv]deps}


### PR DESCRIPTION
This PR adds the `ready_to_serve` attribute to the `sprockets.http.app.Application` class.  If this flag is not set, then the application will return a 503.  It took a little while to figure out that you need to extend both `tornado.web.Application.start_request` and `tornado.web.Application.__call__` for this to work reliably across the various Tornado 4.x versions.

I also _officially_ dropped support for tornado versions before 4.0 since we actually broke it a little while ago.