### PR TITLE
Avoid RecursionError in test

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -449,7 +449,7 @@ class RunnerTests(MockHelper, unittest.TestCase):
 
     def test_that_shutdown_stops_after_timelimit(self):
         def add_timeout(_, callback):
-            time.sleep(0.05)
+            time.sleep(0.1)
             callback()
         self.io_loop.add_timeout = mock.Mock(side_effect=add_timeout)
 


### PR DESCRIPTION
The original sleep of 0.05 resulted in a RecursionError with Python 3.6 on both MacOS 10.12 and Arch Linux.

```
...
  File "/home/draje/Code/GitHub/nvllsvm/sprockets.http/sprockets/http/app.py", line 45, in _maybe_stop
    self.io_loop.add_timeout(now + 1, self._maybe_stop)
  File "/usr/lib64/python3.6/unittest/mock.py", line 939, in __call__
    return _mock_self._mock_call(*args, **kwargs)
  File "/usr/lib64/python3.6/unittest/mock.py", line 1005, in _mock_call
    ret_val = effect(*args, **kwargs)
  File "/home/draje/Code/GitHub/nvllsvm/sprockets.http/tests.py", line 453, in add_timeout
    callback()
  File "/home/draje/Code/GitHub/nvllsvm/sprockets.http/sprockets/http/app.py", line 45, in _maybe_stop
    self.io_loop.add_timeout(now + 1, self._maybe_stop)
  File "/usr/lib64/python3.6/unittest/mock.py", line 939, in __call__
    return _mock_self._mock_call(*args, **kwargs)
  File "/usr/lib64/python3.6/unittest/mock.py", line 944, in _mock_call
    self.called = True
RecursionError: maximum recursion depth exceeded while calling a Python object
-------------------- >> begin captured logging << --------------------
Runner: INFO: starting processes on port 8000
Runner: DEBUG: Shutting down
_ShutdownHandler: INFO: starting IOLoop shutdown process
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 4.779s

FAILED (errors=1)
```