### PR TITLE
Fix documentation builds

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,8 +2,14 @@
 
 Release History
 ===============
-`1.4.0`_ (3 Nov 2016)
----------------------
+
+`Next Release`_
+---------------
+- Workaround https://bitbucket.org/birkenfeld/sphinx-contrib/issues/184/
+  by pinning sphinx in the development environment.
+
+`1.4.0`_ (29 Sep 2017)
+----------------------
 - Separate the concerns of running the application from the callback
   chains.  The latter has been refactored into :mod:`sprockets.http.app`.
   This change is completely invisible to the outside world.

--- a/requires/development.txt
+++ b/requires/development.txt
@@ -1,6 +1,6 @@
 -rinstallation.txt
 -rtesting.txt
 coverage>=4.0,<5
-sphinx>=1.2,<2
+sphinx>=1.2,<1.6.4
 sphinxcontrib-httpdomain>=1.3,<2
 tox>=1.7,<2


### PR DESCRIPTION
Our readthedocs build hasn't updated for almost two years.  This should fix it.

See https://bitbucket.org/birkenfeld/sphinx-contrib/issues/184/