### PR TITLE
Enable uploading docs to pythonhosted.org.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ python:
 - 3.5
 before_install:
 - pip install nose coverage codecov
-- pip install -r requires/testing.txt
+- pip install -r requires/development.txt
 install:
 - pip install -e .
-script: nosetests --with-coverage
+script:
+- nosetests --with-coverage
+- ./setup.py build_sphinx
 after_success:
 - codecov
 sudo: false

--- a/requires/development.txt
+++ b/requires/development.txt
@@ -1,6 +1,6 @@
 -rinstallation.txt
 -rtesting.txt
-coverage>=4.0,<5
-sphinx>=1.2,<1.6.4
-sphinxcontrib-httpdomain>=1.3,<2
-tox>=1.7,<2
+coverage==4.4.2
+sphinx==1.5.6
+sphinxcontrib-httpdomain==1.5.0
+tox==1.9.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ cover-erase = 1
 cover-package = sprockets.http
 cover-html = 1
 cover-html-dir = build/coverage
+
+[upload_docs]
+upload_dir = build/sphinx/html


### PR DESCRIPTION
If this works, then consider ditching readthedocs.org since there is no way to downgrade the sphinx version there /sigh