### PR TITLE
Reuse the listening socket address

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+---
+formats:  # only HTML & json
+  - none
+requirements_file: requires/development.txt
+build:
+  image: latest
+python:
+  version: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
 - pip install -e .
 script:
 - nosetests --with-coverage
-- ./setup.py build_sphinx
 after_success:
 - codecov
 sudo: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016 AWeber Communications
+Copyright (c) 2015-2017 AWeber Communications
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 sprockets.http
 ==============
+
+|Version| |ReadTheDocs| |Travis| |Coverage|
+
 The goal of this library is to make it a little easier to develop great
 HTTP API services using the Tornado web framework.  It concentrates on
 running applications in a reliable & resilient manner and handling errors
@@ -235,3 +238,12 @@ the standard ``serve_traceback`` Tornado option is enabled.
 If the ``sprockets.mixins.mediatype.ContentMixin`` is also extended by your
 base class, ``write-error`` will use the ``ContentMixin.send_response`` method
 for choosing the appropriate response format and sending the error response.
+
+.. |Coverage| image:: https://codecov.io/github/sprockets/sprockets.http/coverage.svg?branch=master
+   :target: https://codecov.io/github/sprockets/sprockets.http
+.. |ReadTheDocs| image:: http://readthedocs.org/projects/sprocketshttp/badge/?version=master
+   :target: https://sprocketshttp.readthedocs.io/
+.. |Travis| image:: https://travis-ci.org/sprockets/sprockets.http.svg
+   :target: https://travis-ci.org/sprockets/sprockets.http
+.. |Version| image:: https://badge.fury.io/py/sprockets.http.svg
+   :target: https://pypi.python.org/pypi/sprockets.http/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,6 @@ html_theme_options = {
     'github_repo': 'sprockets.http',
     'description': 'Tornado application runner',
     'github_banner': True,
-    'travis_button': True,
-    'codecov_button': True,
 }
 html_static_path = ['_static']
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Enable port reuse for Tornado versions newer than 4.3.
+
 `1.4.2`_ (25 Jan 2018)
 ---------------------
 - Allow max_body_size and max_buffer_size to be specified on the http server.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,7 +8,7 @@ Release History
 - Enable port reuse for Tornado versions newer than 4.3.
 
 `1.4.2`_ (25 Jan 2018)
----------------------
+----------------------
 - Allow max_body_size and max_buffer_size to be specified on the http server.
 
 `1.4.1`_ (3 Jan 2018)

--- a/requires/development.txt
+++ b/requires/development.txt
@@ -1,6 +1,7 @@
 -rinstallation.txt
 -rtesting.txt
 coverage==4.4.2
+flake8==3.5.0
 sphinx==1.5.6
 sphinxcontrib-httpdomain==1.5.0
 tox==1.9.2

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -12,6 +12,7 @@ import signal
 import sys
 
 from tornado import httpserver, ioloop
+import tornado
 
 import sprockets.http.app
 
@@ -90,7 +91,12 @@ class Runner(object):
             self.server.listen(port_number)
         else:
             self.logger.info('starting processes on port %d', port_number)
-            self.server.bind(port_number)
+            if tornado.version_info >= (4, 4):
+                self.server.bind(port_number, reuse_port=True)
+            else:
+                self.logger.warning('port reuse disabled, please upgrade to'
+                                    'at least Tornado 4.4')
+                self.server.bind(port_number)
             self.server.start(number_of_procs)
 
     def stop_server(self):

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -131,7 +131,7 @@ class Runner(object):
 
         try:
             self.application.start(iol)
-        except:
+        except Exception:
             self.logger.exception('application terminated during start, '
                                   'exiting')
             sys.exit(70)

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,34 @@
 [tox]
-envlist = py27,py34,py35,pypy,pypy3
+envlist = py27,py34,py35,pypy,pypy3,tornado42,tornado44,tornado45
 indexserver =
 	default = https://pypi.python.org/simple
 toxworkdir = build/tox
 skip_missing_interpreters = True
+use_develop = True
 
 [testenv]
 commands =
-    ./setup.py develop
-    nosetests []
+	nosetests -v
+
 deps =
-    -rrequires/testing.txt
+	-rrequires/testing.txt
+
+[testenv:tornado42]
+commands =
+	{envbindir}/pip install tornado>=4.2,<4.3
+	{[testenv]commands}
+
+[testenv:tornado43]
+commands =
+	{envbindir}/pip install tornado>=4.3,<4.4
+	{[testenv]commands}
+
+[testenv:tornado44]
+commands =
+	{envbindir}/pip install tornado>=4.4,<4.5
+	{[testenv]commands}
+
+[testenv:tornado45]
+commands =
+	{envbindir}/pip install tornado>=4.5,<4.6
+	{[testenv]commands}


### PR DESCRIPTION
Tornado 4.4 added the ability to enable `SO_REUSEPORT` in addition to `SO_REUSEADDR` for listening sockets.  With `SO_REUSEPORT`, restarts of the service will fail until the listening socket leaves the "time wait" state.  I noticed that a service running under [envconsul](https://github.com/hashicorp/envconsul) would fail when the configuration was changed.  This PR changes the start of the HTTP server to enable port reuse if the version of tornado supports it.