### PR TITLE
Runner: remove logging from signal handler.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,14 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Remove logging from the signal handler.  Logger's cannot safely be used
+  from within signal handlers.  See `Thread Safety`_ in the logging module
+  documentation for details.
+
+.. _Thread Safety: https://docs.python.org/3/library/logging.html#thread-safety
+
 `1.5.0`_ (29 Jan 2018)
 ----------------------
 - Enable port reuse for Tornado versions newer than 4.3.

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -139,7 +139,6 @@ class Runner(object):
         iol.start()
 
     def _on_signal(self, signo, frame):
-        self.logger.info('signal %s received, stopping', signo)
         ioloop.IOLoop.instance().add_callback_from_signal(self._shutdown)
 
     def _shutdown(self):


### PR DESCRIPTION
It turns out that logging.Logger **SHOULD NOT** be used in signal handlers. We are running into this elsewhere in the system so that is absolutely no reason to risk it here.  See https://docs.python.org/3/library/logging.html#thread-safety for a mention of this in the Python documentation.

The underlying problem is described in [POSIX 1003.1](http://pubs.opengroup.org/onlinepubs/009695399/functions/xsh_chap02_04.html).  It also lists to 118 C Library functions that are safe to call from within a signal handler.  Note the absence of `fprintf` and a number of other low-level functions that are called from within the logging module.  The implementation of `add_callback_from_signal` only relies on [write(2)](https://github.com/tornadoweb/tornado/blob/master/tornado/platform/posix.py#L52-L56) at it's core provided that the `IOLoop` already exists.