### PR TITLE
Expose Application in package root

### DIFF
--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -6,6 +6,10 @@ import os
 version_info = (1, 5, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
+__all__ = [
+    'run'
+]
+
 
 def run(create_application, settings=None, log_config=None):
     """

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -2,11 +2,14 @@ import logging
 import logging.config
 import os
 
+from .app import Application
+
 
 version_info = (1, 5, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 __all__ = [
+    'Application',
     'run'
 ]
 


### PR DESCRIPTION
I propose this to keep interaction with this sprocket simpler. Since the sprockets philosophy is to keep packages simple and minimal, it makes sense to present the core features in the root import of the package.

Current behavior requires importing `sprockets.http.app` to use the `Application` class. This change exposes that class under the root `sprockets.http` import. 