### PR TITLE
Require log config

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,8 @@ Release History
 ---------------
 - Make shutdown timings configurable.
 - Add :class:`sprockets.http.testing.SprocketsHttpTestCase`.
+- Deprecate calling :func:`sprockets.http.run` without a specified
+  logging configuration.
 
 `2.0.1`_ (5 Mar 2019)
 ----------------------

--- a/examples.py
+++ b/examples.py
@@ -1,6 +1,7 @@
 from tornado import web
 
-from sprockets.http import app, mixins, run
+from sprockets.http import app, mixins
+import sprockets.http
 
 
 class StatusHandler(mixins.ErrorLogger, mixins.ErrorWriter,
@@ -37,4 +38,27 @@ class Application(app.Application):
 
 
 if __name__ == '__main__':
-    run(Application)
+    sprockets.http.run(
+        Application,
+        settings={'port': 8888},
+        log_config={
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'readable': {
+                    'format': '%(levelname)-13s %(name)s: %(message)s',
+                }
+            },
+            'handlers': {
+                'console': {
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'readable',
+                    'stream': 'ext://sys.stdout',
+                }
+            },
+            'root': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            }
+        },
+    )

--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -1,13 +1,16 @@
 import logging
 import logging.config
 import os
+import warnings
 
 
 version_info = (2, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)
 
+_unspecified = object()
 
-def run(create_application, settings=None, log_config=None):
+
+def run(create_application, settings=None, log_config=_unspecified):
     """
     Run a Tornado create_application.
 
@@ -61,8 +64,16 @@ def run(create_application, settings=None, log_config=None):
     debug_mode = bool(app_settings.get('debug',
                                        int(os.environ.get('DEBUG', 0)) != 0))
     app_settings['debug'] = debug_mode
-    logging.config.dictConfig(_get_logging_config(debug_mode)
-                              if log_config is None else log_config)
+    if log_config is _unspecified:
+        warnings.warn(
+            'calling sprockets.http.run without logging configuration is '
+            'deprecated and will fail in the future', DeprecationWarning)
+        logging.config.dictConfig(_get_logging_config(debug_mode))
+        logging.warning(
+            'calling sprockets.http.run without logging configuration is '
+            'deprecated and will fail in the future')
+    else:
+        logging.config.dictConfig(log_config)
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
     num_procs = int(app_settings.pop('number_of_procs', '0'))

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,7 @@ import json
 import time
 import unittest
 import uuid
+import warnings
 
 from tornado import concurrent, httpserver, httputil, ioloop, testing, web
 
@@ -295,6 +296,14 @@ class RunTests(MockHelper, unittest.TestCase):
         sprockets.http.run(mock.Mock(), log_config=mock.sentinel.config)
         self.logging_dict_config.assert_called_once_with(
             mock.sentinel.config)
+
+    def test_that_not_specifying_logging_config_is_deprecated(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter('always')
+            sprockets.http.run(mock.Mock())
+
+        self.assertEqual(len(captured), 1)
+        self.assertTrue(issubclass(captured[0].category, DeprecationWarning))
 
 
 class CallbackTests(MockHelper, unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -7,6 +7,7 @@ import os
 import json
 import time
 import unittest
+import uuid
 
 from tornado import concurrent, httpserver, httputil, ioloop, testing, web
 
@@ -55,16 +56,19 @@ class MockHelper(unittest.TestCase):
 
 
 @contextlib.contextmanager
-def override_environment_variable(name, value):
-    stash = os.environ.pop(name, None)
-    if value is not None:
-        os.environ[name] = value
+def override_environment_variable(**env_vars):
+    stash = {}
+    for name, value in env_vars.items():
+        stash[name] = os.environ.pop(name, None)
+        if value is not None:
+            os.environ[name] = value
     try:
         yield
     finally:
-        os.environ.pop(name, None)
-        if stash is not None:
-            os.environ[name] = stash
+        for name, value in stash.items():
+            os.environ.pop(name, None)
+            if value is not None:
+                os.environ[name] = value
 
 
 class ErrorLoggerTests(testing.AsyncHTTPTestCase):
@@ -240,21 +244,21 @@ class RunTests(MockHelper, unittest.TestCase):
 
     def test_that_debug_envvar_enables_debug_flag(self):
         create_app = mock.Mock()
-        with override_environment_variable('DEBUG', '1'):
+        with override_environment_variable(DEBUG='1'):
             sprockets.http.run(create_app)
             create_app.assert_called_once_with(debug=True)
             self.get_logging_config.assert_called_once_with(True)
 
     def test_that_false_debug_envvar_disables_debug_flag(self):
         create_app = mock.Mock()
-        with override_environment_variable('DEBUG', '0'):
+        with override_environment_variable(DEBUG='0'):
             sprockets.http.run(create_app)
             create_app.assert_called_once_with(debug=False)
             self.get_logging_config.assert_called_once_with(False)
 
     def test_that_unset_debug_envvar_disables_debug_flag(self):
         create_app = mock.Mock()
-        with override_environment_variable('DEBUG', None):
+        with override_environment_variable(DEBUG=None):
             sprockets.http.run(create_app)
             create_app.assert_called_once_with(debug=False)
             self.get_logging_config.assert_called_once_with(False)
@@ -264,7 +268,7 @@ class RunTests(MockHelper, unittest.TestCase):
         self.runner_instance.run.assert_called_once_with(8000, mock.ANY)
 
     def test_that_port_envvar_sets_port_number(self):
-        with override_environment_variable('PORT', '8888'):
+        with override_environment_variable(PORT='8888'):
             sprockets.http.run(mock.Mock())
             self.runner_instance.run.assert_called_once_with(8888, mock.ANY)
 
@@ -642,3 +646,41 @@ class TestCaseTests(unittest.TestCase):
         test_case.app.stop.assert_called_once_with(
             test_case.io_loop, test_case.shutdown_limit,
             test_case.wait_timeout)
+
+
+class CorrelationFilterTests(unittest.TestCase):
+    def setUp(self):
+        super(CorrelationFilterTests, self).setUp()
+        self.logger = logging.getLogger()
+        self.record = self.logger.makeRecord(
+            'name', logging.INFO, 'functionName', 42, 'hello %s',
+            tuple(['world']), (None, None, None))
+        self.filter = sprockets.http._CorrelationFilter()
+
+    def test_that_correlation_filter_adds_correlation_id(self):
+        self.filter.filter(self.record)
+        self.assertTrue(hasattr(self.record, 'correlation-id'))
+
+    def test_that_correlation_filter_does_not_overwrite_correlation_id(self):
+        some_value = str(uuid.uuid4())
+        setattr(self.record, 'correlation-id', some_value)
+        self.filter.filter(self.record)
+        self.assertEqual(getattr(self.record, 'correlation-id'), some_value)
+
+
+class LoggingConfigurationTests(unittest.TestCase):
+    def test_that_debug_sets_log_level_to_debug(self):
+        config = sprockets.http._get_logging_config(True)
+        self.assertEqual(config['root']['level'], 'DEBUG')
+
+    def test_that_not_debug_sets_log_level_to_info(self):
+        config = sprockets.http._get_logging_config(False)
+        self.assertEqual(config['root']['level'], 'INFO')
+
+    def test_that_format_includes_sd_when_service_and_env_are_set(self):
+        with override_environment_variable(SERVICE='service',
+                                           ENVIRONMENT='whatever'):
+            config = sprockets.http._get_logging_config(False)
+        fmt_name = list(config['formatters'].keys())[0]
+        self.assertIn('service="service" environment="whatever"',
+                      config['formatters'][fmt_name]['format'])


### PR DESCRIPTION
This PR deprecates calling `sprockets.http.run` without a logging configuration dictionary.  The value that is currently embedded is a barely usable default.  This is something that the application should always specify IMO.

I would like to revive `sprockets.logging` and move the `ErrorLogger` into there as well as some good default logging configuration blobs.  The functionality of this version is identical.  It simple deprecates not specifying a logging configuration.  Once we figure out what to do with logging configuration, we can officially remove the functionality.  I log a warning that this will fail in the future.  My intent is to not call `logging.dictConfig` if `None` is specified instead.  I want to log message to tell everyone that *action is expected* so it is a little stronger than necessary.

Oh ... I also pushed some more tests to get better coverage numbers.