### PR TITLE
Use loop-specific create_task in Application.stop.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,13 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- :meth:`sprockets.http.app.CallbackManager.stop` no longer requires the
+  event loop to be running (fixes `#34`_)
+
+.. _#34: https://github.com/sprockets/sprockets.http/issues/34
+
 `2.1.0`_ (9 Oct 2019)
 ---------------------
 - Make shutdown timings configurable.

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -127,7 +127,8 @@ class CallbackManager:
                 maybe_future = callback(self.tornado_application)
 
                 if asyncio.iscoroutine(maybe_future):
-                    maybe_future = asyncio.create_task(maybe_future)
+                    maybe_future = io_loop.asyncio_loop.create_task(
+                        maybe_future)
 
                 if concurrent.is_future(maybe_future):
                     shutdown.add_future(maybe_future)


### PR DESCRIPTION
Calling `asyncio.create_task()` requires a running event loop which we cannot guarantee.  The event loop is not running when `stop` is called in `testing.SprocketsHttpTestCase.tearDown`.  This fixes #34.