### PR TITLE
asyncio.Task.all_tasks was removed in Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
+os: linux
 dist: xenial
 python:
 - 3.5
 - 3.6
 - 3.7
+- 3.8
 install:
 - pip install -r requires/development.txt codecov
 script:
@@ -12,11 +14,10 @@ script:
 - flake8
 after_success:
 - codecov
-sudo: false
 deploy:
   distributions: sdist bdist_wheel
   provider: pypi
-  user: sprockets
+  username: sprockets
   password:
     secure: ARvFw5CHqQZqPOkJXxQSe7EAEbX1yt7FiBTtzz8Gd6XndbY10HVCSWhGYeldm9LevvQc9p77pBEvsl+bXGQbJ3NW/r/U5PADaFdmi4bxmXN8yc+dFKzn72MpZfL+kCV2T/HutuOY6dQa4okTkKVV+sqwPLKPhL69zH/PxQg8qe4=
   on:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Release History
 ===============
 
+Next release
+------------
+- Updated to support Python 3.9.  ``asyncio.Task.all_tasks`` was removed
+  so I switched to ``asyncio.all_tasks`` if it exists.
+
 `2.1.1`_ (19 Feb 2020)
 ----------------------
 - :meth:`sprockets.http.app.CallbackManager.stop` no longer requires the

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,10 +3,12 @@
 Release History
 ===============
 
-Next release
-------------
+`Next release`_
+---------------
 - Updated to support Python 3.9.  ``asyncio.Task.all_tasks`` was removed
   so I switched to ``asyncio.all_tasks`` if it exists.
+- Deprecate calling ``sprockets.http.run`` with anything that isn't a
+  ``sprockets.app.Application`` instance.
 
 `2.1.1`_ (19 Feb 2020)
 ----------------------

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries',

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -41,12 +41,18 @@ class _ShutdownHandler:
         self._maybe_stop()
 
     def _maybe_stop(self):
+        all_tasks = self._all_tasks()
         now = self.io_loop.time()
-        if now < self.__deadline and asyncio.Task.all_tasks():
+        if now < self.__deadline and all_tasks:
             self.io_loop.add_timeout(now + self.wait_timeout, self._maybe_stop)
         else:
             self.io_loop.stop()
             self.logger.info('stopped IOLoop')
+
+    def _all_tasks(self):
+        if hasattr(asyncio, 'all_tasks'):
+            return asyncio.all_tasks(self.io_loop.asyncio_loop)
+        return asyncio.Task.all_tasks(self.io_loop.asyncio_loop)
 
 
 class CallbackManager:

--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import sys
+import warnings
 
 from tornado import concurrent, web
 
@@ -260,6 +261,11 @@ def wrap_application(application, before_run, on_start, shutdown):
     shutdown = [] if shutdown is None else shutdown
 
     if not isinstance(application, Application):
+        warnings.warn(
+            'sprockets.http.run is only going to accept '
+            'sprockets.app.Application instances in 3.0, '
+            'was called with {}'.format(type(application).__name__),
+            category=DeprecationWarning)
         application = _ApplicationAdapter(application)
 
     application.before_run_callbacks.extend(before_run)

--- a/tests.py
+++ b/tests.py
@@ -469,6 +469,21 @@ class RunnerTests(MockHelper, unittest.TestCase):
         self.io_loop.stop.assert_called_once_with()
         self.assertNotEqual(self.io_loop._timeouts, [])
 
+    def test_that_calling_with_non_sprockets_application_is_deprecated(self):
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.filterwarnings(action='always', module='sprockets')
+            sprockets.http.runner.Runner(web.Application())
+        for warning in captured:
+            if 'sprockets.app.Application' in str(warning.message):
+                break
+        else:
+            self.fail('expected deprecation warning from runnr.Runner')
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.filterwarnings(action='always', module='sprockets')
+            sprockets.http.runner.Runner(sprockets.http.app.Application())
+        self.assertEqual(len(captured), 0)
+
 
 class AsyncRunTests(unittest.TestCase):
 

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,4 @@
 from unittest import mock
-import asyncio
 import contextlib
 import distutils.dist
 import distutils.errors
@@ -724,49 +723,55 @@ class ShutdownHandlerTests(unittest.TestCase):
         self.assertIn('Injected Failure', cm.output[0])
 
     def test_that_maybe_stop_retries_until_tasks_are_complete(self):
-        async def f():
-            pass
-
         fake_loop = unittest.mock.Mock()
         fake_loop.time.return_value = 10
 
-        loop = asyncio.get_event_loop()
-        tasks = [loop.create_task(f()) for _ in range(5)]
+        wait_timeout = 1.0
+        handler = sprockets.http.app._ShutdownHandler(
+            fake_loop, 5.0, wait_timeout)
 
-        handler = sprockets.http.app._ShutdownHandler(fake_loop, 5.0, 0.0)
-        handler.on_shutdown_ready()  # sets __deadline to 15
+        handler._all_tasks = unittest.mock.Mock()
+        handler._all_tasks.return_value = ['does-not-matter']
+
+        # on_shutdown_ready should schedule the callback since there
+        # are outstanding tasks
+        handler.on_shutdown_ready()
+        fake_loop.add_timeout.assert_called_once_with(
+            fake_loop.time.return_value + wait_timeout,
+            handler._maybe_stop)
         fake_loop.add_timeout.reset_mock()
 
-        while tasks:
-            task = tasks.pop()
-            handler._maybe_stop()
-            fake_loop.add_timeout.assert_called_once_with(
-                unittest.mock.ANY, handler._maybe_stop)
-            fake_loop.add_timeout.reset_mock()
-            loop.run_until_complete(task)
-            del task
+        # the callback should re-schedule since there are still
+        # outstanding tasks
+        handler._maybe_stop()
+        fake_loop.add_timeout.assert_called_once_with(
+            fake_loop.time.return_value + wait_timeout,
+            handler._maybe_stop)
+        fake_loop.add_timeout.reset_mock()
 
+        # when all of the tasks are finished, the loop is stopped
+        handler._all_tasks.return_value = []
         handler._maybe_stop()
         fake_loop.stop.assert_called_once_with()
 
     def test_that_maybe_stop_terminates_when_deadline_reached(self):
         fake_loop = unittest.mock.Mock()
-        fake_loop.time.return_value = 10
 
-        loop = asyncio.get_event_loop()
-        loop.create_task(asyncio.sleep(10))
+        shutdown_limit = 10
+        ticks = range(0, shutdown_limit)
+        handler = sprockets.http.app._ShutdownHandler(
+            fake_loop, shutdown_limit, 1.0)
 
-        handler = sprockets.http.app._ShutdownHandler(fake_loop, 5.0, 0.0)
-        handler.on_shutdown_ready()  # sets __deadline to 15
-        fake_loop.add_timeout.reset_mock()
+        handler._all_tasks = unittest.mock.Mock()
+        handler._all_tasks.return_value = ['does-not-matter']
 
-        while fake_loop.time.return_value < 15:
+        fake_loop.time.return_value = 0.0
+        handler.on_shutdown_ready()  # sets deadline to 0 + shutdown_limit
+        for time_value in ticks:  # tick down
+            fake_loop.time.return_value = float(time_value)
             handler._maybe_stop()
-            fake_loop.add_timeout.assert_called_once_with(
-                unittest.mock.ANY, handler._maybe_stop)
-            fake_loop.add_timeout.reset_mock()
-            fake_loop.time.return_value += 1
+            fake_loop.stop.assert_not_called()
 
+        fake_loop.time.return_value = float(shutdown_limit)
         handler._maybe_stop()
         fake_loop.stop.assert_called_once_with()
-        self.assertEqual(len(asyncio.Task.all_tasks(loop)), 1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,tornado,tornado50
+envlist = py35,py36,py37,py38,py39,tornado,tornado50
 indexserver =
 	default = https://pypi.python.org/simple
 toxworkdir = build/tox
@@ -20,5 +20,5 @@ commands =
 
 [testenv:tornado50]
 commands =
-	{envbindir}/pip install tornado=5.0
+	{envbindir}/pip install tornado==5.0
 	{[testenv]commands}


### PR DESCRIPTION
`asyncio.Task.all_tasks` was the original way to get a list of all asyncio tasks for a loop.  `asyncio.all_tasks` was added in Python 3.7 since it is considered a cleaner interface.  The `asyncio.Task.all_tasks` method was deprecated at that point and was removed in Python 3.9.  This PR calls `asyncio.all_tasks` preferentially.

Looking forward, we need to look at the deprecations listed in [3.9](https://docs.python.org/3.9/whatsnew/3.9.html#deprecated) and make sure that we are safe.