### PR TITLE
Add custom request logging

### DIFF
--- a/sprockets/http/app.py
+++ b/sprockets/http/app.py
@@ -242,7 +242,7 @@ class Application(CallbackManager, web.Application):
 
         log.access_log.log(
             log_level,
-            '%s %s %s [%s] "%s %s %s" %d %s "%s" "%s" (secs:%.03f)',
+            '%s %s %s [%s] "%s %s %s" %d "%s" %s "%s" "%s" (secs:%.03f)',
             handler.request.remote_ip,
             '-',  # RFC-1413 user identifier
             handler.get_current_user() or '-',
@@ -251,6 +251,7 @@ class Application(CallbackManager, web.Application):
             handler.request.uri,
             handler.request.version,
             status,
+            handler._reason or '-',
             bytes_written,
             handler.request.headers.get('Referer', '-'),
             handler.request.headers.get('User-Agent', '-'),

--- a/tests.py
+++ b/tests.py
@@ -814,11 +814,12 @@ class AccessLogTests(sprockets.http.testing.SprocketsHttpTestCase):
         when = datetime.datetime.fromtimestamp(request._start_time,
                                                datetime.timezone.utc)
         expected_message = re.compile(
-            r'^%s - - %s "%s %s %s" %d - "-" "-" \(secs:([^)]*)\)' %
+            r'^%s - - %s "%s %s %s" %d "%s" - "-" "-" \(secs:([^)]*)\)' %
             (request.remote_ip,
              re.escape(
                  when.strftime('[%d/%b/%Y:%H:%M:%S %z]')), request.method,
-             re.escape(request.uri), request.version, handler.get_status()))
+             re.escape(request.uri), request.version, handler.get_status(),
+             handler._reason))
         message = context.records[0].getMessage()
         match = expected_message.match(message)
         if match is None:

--- a/tests.py
+++ b/tests.py
@@ -1,16 +1,18 @@
 from unittest import mock
 import contextlib
+import datetime
 import distutils.dist
 import distutils.errors
+import json
 import logging
 import os
-import json
+import re
 import time
 import unittest
 import uuid
 import warnings
 
-from tornado import concurrent, httpserver, httputil, ioloop, testing, web
+from tornado import concurrent, httpserver, httputil, ioloop, log, testing, web
 
 import sprockets.http.app
 import sprockets.http.mixins
@@ -790,3 +792,83 @@ class ShutdownHandlerTests(unittest.TestCase):
         fake_loop.time.return_value = float(shutdown_limit)
         handler._maybe_stop()
         fake_loop.stop.assert_called_once_with()
+
+
+class AccessLogTests(sprockets.http.testing.SprocketsHttpTestCase):
+
+    def get_app(self):
+        self.app = sprockets.http.app.Application([])
+        return self.app
+
+    def test_that_log_request_uses_expected_format(self):
+        request = httputil.HTTPServerRequest('GET', '/search?q=42')
+        request.remote_ip = '1.1.1.1'
+        request._start_time = time.time()
+        request.connection = unittest.mock.Mock()
+
+        handler = web.RequestHandler(self.app, request)
+
+        with self.assertLogs(log.access_log) as context:
+            self.app.log_request(handler)
+
+        when = datetime.datetime.fromtimestamp(request._start_time,
+                                               datetime.timezone.utc)
+        expected_message = re.compile(
+            r'^%s - - %s "%s %s %s" %d - "-" "-" \(secs:([^)]*)\)' %
+            (request.remote_ip,
+             re.escape(
+                 when.strftime('[%d/%b/%Y:%H:%M:%S %z]')), request.method,
+             re.escape(request.uri), request.version, handler.get_status()))
+        message = context.records[0].getMessage()
+        match = expected_message.match(message)
+        if match is None:
+            self.fail(f'"{message}" did not match "{expected_message}"')
+        try:
+            float(match.group(1))
+        except ValueError:
+            self.fail(f'Expected {match.group(1)} to be a float')
+
+    def test_that_log_request_uses_correct_log_level(self):
+        expectations = {
+            200: logging.INFO,
+            303: logging.INFO,
+            400: logging.WARNING,
+            404: logging.WARNING,
+            500: logging.ERROR,
+            599: logging.ERROR,
+        }
+
+        request = httputil.HTTPServerRequest('GET', '/search?q=42')
+        request.remote_ip = '1.1.1.1'
+        request._start_time = time.time()
+        request.connection = unittest.mock.Mock()
+
+        for status, log_level in expectations.items():
+            handler = web.RequestHandler(self.app, request)
+            handler.set_status(status)
+            with self.assertLogs(log.access_log, log_level) as context:
+                self.app.log_request(handler)
+            self.assertEqual(context.records[0].levelno, log_level)
+
+    def test_that_log_request_uses_correct_log_level_with_only_failures(self):
+        expectations = {
+            200: logging.DEBUG,
+            303: logging.DEBUG,
+            400: logging.WARNING,
+            404: logging.WARNING,
+            500: logging.ERROR,
+            599: logging.ERROR,
+        }
+
+        request = httputil.HTTPServerRequest('GET', '/search?q=42')
+        request.remote_ip = '1.1.1.1'
+        request._start_time = time.time()
+        request.connection = unittest.mock.Mock()
+
+        for status, log_level in expectations.items():
+            handler = web.RequestHandler(self.app, request)
+            handler.access_log_failures_only = True
+            handler.set_status(status)
+            with self.assertLogs(log.access_log, log_level) as context:
+                self.app.log_request(handler)
+            self.assertEqual(context.records[0].levelno, log_level)


### PR DESCRIPTION
- Same format as service-cookiecutter.
- Uses an optional `access_log_failures_only` handler attribute to suppress access log entries for successful HTTP responses.