### PR TITLE
Default to starting a single process

### DIFF
--- a/sprockets/http/__init__.py
+++ b/sprockets/http/__init__.py
@@ -90,7 +90,7 @@ def run(create_application, settings=None, log_config=_unspecified):
         logging.config.dictConfig(log_config)
 
     port_number = int(app_settings.pop('port', os.environ.get('PORT', 8000)))
-    num_procs = int(app_settings.pop('number_of_procs', '0'))
+    num_procs = int(app_settings.pop('number_of_procs', 1))
     app = create_application(**app_settings)
 
     if 'sentry_sdk' in sys.modules:

--- a/sprockets/http/runner.py
+++ b/sprockets/http/runner.py
@@ -58,7 +58,7 @@ class Runner:
         self.shutdown_limit = 5.0
         self.wait_timeout = 1.0
 
-    def start_server(self, port_number, number_of_procs=0):
+    def start_server(self, port_number, number_of_procs=1):
         """
         Create a HTTP server and start it.
 
@@ -99,7 +99,7 @@ class Runner:
         """Stop the HTTP Server"""
         self.server.stop()
 
-    def run(self, port_number, number_of_procs=0):
+    def run(self, port_number, number_of_procs=1):
         """
         Create the server and run the IOLoop.
 

--- a/tests.py
+++ b/tests.py
@@ -280,13 +280,13 @@ class RunTests(MockHelper, unittest.TestCase):
         sprockets.http.run(self.create_app, settings={'port': 8888})
         self.runner_instance.run.assert_called_once_with(8888, mock.ANY)
 
-    def test_that_number_of_procs_defaults_to_zero(self):
+    def test_that_number_of_procs_defaults_to_one(self):
         sprockets.http.run(self.create_app)
-        self.runner_instance.run.assert_called_once_with(mock.ANY, 0)
+        self.runner_instance.run.assert_called_once_with(mock.ANY, 1)
 
     def test_that_number_of_process_kwarg_sets_number_of_procs(self):
-        sprockets.http.run(self.create_app, settings={'number_of_procs': 1})
-        self.runner_instance.run.assert_called_once_with(mock.ANY, 1)
+        sprockets.http.run(self.create_app, settings={'number_of_procs': 2})
+        self.runner_instance.run.assert_called_once_with(mock.ANY, 2)
 
     def test_that_logging_dict_config_is_called_appropriately(self):
         sprockets.http.run(self.create_app)
@@ -455,7 +455,7 @@ class RunnerTests(MockHelper, unittest.TestCase):
         self.httpserver_module.HTTPServer.assert_called_once_with(
             self.application, **self.application.settings)
 
-    def test_that_production_run_starts_in_multiprocess_mode(self):
+    def test_that_production_run_starts_in_single_process_mode(self):
         runner = sprockets.http.runner.Runner(self.application)
         runner.run(8000)
 
@@ -463,7 +463,7 @@ class RunnerTests(MockHelper, unittest.TestCase):
         args, kwargs = self.http_server.bind.call_args_list[0]
         self.assertEqual(args, (8000, ))
 
-        self.http_server.start.assert_called_once_with(0)
+        self.http_server.start.assert_called_once_with(1)
 
     def test_that_production_enables_reuse_port(self):
         runner = sprockets.http.runner.Runner(self.application)


### PR DESCRIPTION
Using multiple processes with envconsul can result in orphan processes.

Resolves https://github.com/sprockets/sprockets.http/issues/41